### PR TITLE
Add initial CLI script with build and hatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ Inspired by the metaphor of the egg—slow to build, instant to hatch—egg file
 - See [SECURITY.md](SECURITY.md) for sandboxing and threat model.
 - See [CONTRIBUTING.md](CONTRIBUTING.md) if you want to join the hatch!
 
+You can try the placeholder command-line interface today:
+
+```bash
+python egg_cli.py build  # assemble an egg (placeholder)
+python egg_cli.py hatch  # run an egg (placeholder)
+```
+
 ---
 
 ## License

--- a/egg_cli.py
+++ b/egg_cli.py
@@ -1,0 +1,32 @@
+import argparse
+
+
+def build(_args: argparse.Namespace) -> None:
+    """Placeholder for building an egg file."""
+    print("[build] Building egg... (placeholder)")
+
+
+def hatch(_args: argparse.Namespace) -> None:
+    """Placeholder for hatching an egg file."""
+    print("[hatch] Hatching egg... (placeholder)")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Egg builder and hatcher CLI")
+    subparsers = parser.add_subparsers(dest="command")
+
+    parser_build = subparsers.add_parser("build", help="Build an egg file")
+    parser_build.set_defaults(func=build)
+
+    parser_hatch = subparsers.add_parser("hatch", help="Hatch an egg file")
+    parser_hatch.set_defaults(func=hatch)
+
+    args = parser.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a minimal `egg_cli.py` with `build` and `hatch` subcommands
- show how to run the CLI in the README

## Testing
- `python3 -m py_compile egg_cli.py`
- `python3 egg_cli.py build`
- `python3 egg_cli.py hatch`


------
https://chatgpt.com/codex/tasks/task_e_68504d877af483288a9a0964264b4bce