### PR TITLE
Add example manifest and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Inspired by the metaphor of the egg—slow to build, instant to hatch—egg file
 ## Getting Started
 
 *Coming soon!* This project is in early stages.
+You can start experimenting with a minimal two-language notebook using
+[`examples/manifest.yaml`](examples/manifest.yaml).
 
 - See [AGENTS.md](AGENTS.md) for the agent and build pipeline design.
 - See [FORMAT.md](FORMAT.md) for the egg file format specification.

--- a/examples/hello.R
+++ b/examples/hello.R
@@ -1,0 +1,1 @@
+print("Hello from R")

--- a/examples/hello.py
+++ b/examples/hello.py
@@ -1,0 +1,1 @@
+print("Hello from Python")

--- a/examples/manifest.yaml
+++ b/examples/manifest.yaml
@@ -1,0 +1,7 @@
+name: "Demo Notebook"
+description: "Simple two-language example"
+cells:
+  - language: python
+    source: hello.py
+  - language: r
+    source: hello.R

--- a/format.md
+++ b/format.md
@@ -28,6 +28,9 @@ The `.egg` file is a hierarchical, chunked container optimized for instant, brea
 [Header/TOC][Static Table L1][Static Table L2][Manifest][Notebook][Block A][Block B]...[Heap1][Heap2]...
 ```
 
+For a concrete starting template, see the sample manifest in
+[`examples/manifest.yaml`](examples/manifest.yaml).
+
 ### Breadth-First Loading
 
 - UI loads Layer 1 & 2 instantly (title, author, structure, text, previews).


### PR DESCRIPTION
## Summary
- add simple two-language sample under `examples/`
- reference the example manifest in README and FORMAT docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68504d89eeb48328b108814770d66290