### PR TITLE
Add flake8 linter to CI

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest
+        pip install pytest flake8 black
+    - name: Lint
+      run: |
+        flake8
+        black --check .
     - name: Run tests
       run: |
         pytest -q

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,13 +1,16 @@
 import argparse
 import os
 import sys
+
 sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
-import egg_cli
+import egg_cli  # noqa: E402
+
 
 def test_build(capsys):
     egg_cli.build(argparse.Namespace())
     captured = capsys.readouterr()
     assert "[build] Building egg... (placeholder)" in captured.out
+
 
 def test_hatch(capsys):
     egg_cli.hatch(argparse.Namespace())


### PR DESCRIPTION
## Summary
- add flake8 config with short settings
- install flake8 and black in CI
- run linter as part of workflow
- update test file to satisfy flake8 rules

## Testing
- `flake8`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685050793aa4832882e49da2f1e332bf