### PR TITLE
Add auto-format step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,19 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pytest flake8 black
+    - name: Format code with Black
+      run: |
+        black .
+    - name: Commit formatted code
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        if [ -n "$(git status --porcelain)" ]; then
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          git commit -am "chore: format with black"
+          git push
+        fi
     - name: Lint
       run: |
         flake8


### PR DESCRIPTION
## Summary
- have GitHub Actions format with black
- commit auto-formatted code back to the branch

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68505155a8f48328bb826f8c2fe5ca4c