### PR TITLE
Add MIT license metadata to pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,8 @@ authors = [{ name = "egg contributors" }]
 readme = "README.md"
 description = "CLI tools for the egg file format"
 requires-python = ">=3.8"
+license = { text = "MIT" }
+classifiers = ["License :: OSI Approved :: MIT License"]
 
 [project.scripts]
 egg = "egg_cli:main"


### PR DESCRIPTION
## Summary
- add `license` field to project metadata
- document license classifier

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850526b142083289c5c2e09e5f4553a