### PR TITLE
Add CLI version option and improve tests

### DIFF
--- a/egg_cli.py
+++ b/egg_cli.py
@@ -1,5 +1,7 @@
 import argparse
 
+__version__ = "0.1.0"
+
 
 def build(_args: argparse.Namespace) -> None:
     """Build an egg file from sources.
@@ -37,6 +39,12 @@ def main() -> None:
         None.
     """
     parser = argparse.ArgumentParser(description="Egg builder and hatcher CLI")
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
+        help="Show program version and exit",
+    )
     subparsers = parser.add_subparsers(dest="command")
 
     parser_build = subparsers.add_parser("build", help="Build an egg file")
@@ -50,6 +58,7 @@ def main() -> None:
         args.func(args)
     else:
         parser.print_help()
+        parser.exit()
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
 import egg_cli  # noqa: E402
+import pytest
 
 
 def test_build(monkeypatch, capsys):
@@ -17,3 +18,19 @@ def test_hatch(monkeypatch, capsys):
     egg_cli.main()
     captured = capsys.readouterr()
     assert "[hatch] Hatching egg... (placeholder)" in captured.out
+
+
+def test_help_without_subcommand(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["egg_cli.py"])
+    with pytest.raises(SystemExit):
+        egg_cli.main()
+    captured = capsys.readouterr()
+    assert "usage:" in captured.out
+
+
+def test_version_option(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["egg_cli.py", "--version"])
+    with pytest.raises(SystemExit):
+        egg_cli.main()
+    captured = capsys.readouterr()
+    assert egg_cli.__version__ in captured.out


### PR DESCRIPTION
## Summary
- expose a `__version__` constant and `--version` flag in `egg_cli`
- exit after printing help when no subcommand is provided
- test help and version behaviour in `tests/test_cli.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685052670924832880c141e72fde2e8e