### PR TITLE
Add CLI version flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ After installation the `egg` command becomes available:
 ```bash
 egg build  # assemble an egg (placeholder)
 egg hatch  # run an egg (placeholder)
+egg --version  # show CLI version
 ```
 
 ### Example Build Walkthrough

--- a/egg_cli.py
+++ b/egg_cli.py
@@ -1,5 +1,7 @@
 import argparse
 
+__version__ = "0.1.0"
+
 
 def build(_args: argparse.Namespace) -> None:
     """Build an egg file from sources.
@@ -37,6 +39,7 @@ def main() -> None:
         None.
     """
     parser = argparse.ArgumentParser(description="Egg builder and hatcher CLI")
+    parser.add_argument('--version', action='version', version=__version__)
     subparsers = parser.add_subparsers(dest="command")
 
     parser_build = subparsers.add_parser("build", help="Build an egg file")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
 import egg_cli  # noqa: E402
@@ -17,3 +18,11 @@ def test_hatch(monkeypatch, capsys):
     egg_cli.main()
     captured = capsys.readouterr()
     assert "[hatch] Hatching egg... (placeholder)" in captured.out
+
+
+def test_version(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["egg_cli.py", "--version"])
+    with pytest.raises(SystemExit):
+        egg_cli.main()
+    captured = capsys.readouterr()
+    assert egg_cli.__version__ in captured.out


### PR DESCRIPTION
## Summary
- expose package version via `--version` flag
- document `egg --version` usage in README
- test that `--version` prints the CLI version

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68505262c49c8328b37c67eb3768536d