### PR TITLE
Add manifest support to CLI build command

### DIFF
--- a/egg_cli.py
+++ b/egg_cli.py
@@ -1,17 +1,39 @@
 import argparse
+import os
+
+import yaml
 
 
-def build(_args: argparse.Namespace) -> None:
+def parse_manifest(path: str) -> list[str]:
+    """Parse a manifest file and return resolved source paths."""
+    with open(path, "r", encoding="utf-8") as f:
+        manifest = yaml.safe_load(f)
+
+    base_dir = os.path.dirname(os.path.abspath(path))
+    resolved = []
+    for cell in manifest.get("cells", []):
+        source = cell.get("source")
+        if source:
+            resolved.append(os.path.abspath(os.path.join(base_dir, source)))
+    return resolved
+
+
+def build(args: argparse.Namespace) -> None:
     """Build an egg file from sources.
 
     Args:
-        _args: Parsed command line arguments for the ``build`` subcommand. The
-            current placeholder does not expect any specific options.
+        args: Parsed command line arguments for the ``build`` subcommand.
 
     Returns:
         None. Prints a placeholder message to indicate the command ran.
     """
+    resolved = []
+    if args.manifest:
+        resolved = parse_manifest(args.manifest)
+
     print("[build] Building egg... (placeholder)")
+    for path in resolved:
+        print(path)
 
 
 def hatch(_args: argparse.Namespace) -> None:
@@ -40,6 +62,16 @@ def main() -> None:
     subparsers = parser.add_subparsers(dest="command")
 
     parser_build = subparsers.add_parser("build", help="Build an egg file")
+    parser_build.add_argument(
+        "--manifest",
+        type=str,
+        help="Path to the manifest YAML",
+    )
+    parser_build.add_argument(
+        "--output",
+        type=str,
+        help="Output egg file path",
+    )
     parser_build.set_defaults(func=build)
 
     parser_hatch = subparsers.add_parser("hatch", help="Hatch an egg file")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,11 +5,28 @@ sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
 import egg_cli  # noqa: E402
 
 
-def test_build(monkeypatch, capsys):
-    monkeypatch.setattr(sys, "argv", ["egg_cli.py", "build"])
+def test_build(monkeypatch, capsys, tmp_path):
+    manifest = tmp_path / "manifest.yaml"
+    (tmp_path / "script.py").write_text("print('hi')")
+    manifest.write_text(
+        "name: t\ncells:\n- language: python\n  source: script.py\n"
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "egg_cli.py",
+            "build",
+            "--manifest",
+            str(manifest),
+            "--output",
+            "out.egg",
+        ],
+    )
     egg_cli.main()
     captured = capsys.readouterr()
     assert "[build] Building egg... (placeholder)" in captured.out
+    assert str((tmp_path / "script.py").resolve()) in captured.out
 
 
 def test_hatch(monkeypatch, capsys):


### PR DESCRIPTION
## Summary
- parse manifests and resolve paths
- add `--manifest` and `--output` options to `egg build`
- test new CLI options with monkeypatch

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685052e752d48328b6bc835d04617ccb