### PR TITLE
Fix build command to use composer

### DIFF
--- a/egg_cli.py
+++ b/egg_cli.py
@@ -1,52 +1,26 @@
 import argparse
-
 from pathlib import Path
 
+from egg.composer import compose
+
+__version__ = "0.1.0"
+
 
 def build(args: argparse.Namespace) -> None:
-    """Build an egg file from sources.
+    """Build an egg file from sources."""
+    compose(args.manifest, args.output)
+    print(f"[build] Building egg from {args.manifest} -> {args.output}")
 
-    Args:
-        args: Parsed command line arguments for the ``build`` subcommand.
-            ``args.manifest`` points to the manifest YAML file and
-            ``args.output`` specifies the resulting egg path.
-
-def build(args: argparse.Namespace) -> None:
-    """Build an egg file from sources.
-
-    Parameters
-    ----------
-    args : argparse.Namespace
-        Parsed CLI arguments with ``manifest`` and ``output`` attributes.
-    """
-
-    print(f"[build] Building egg from {args.manifest} -> {args.output} (placeholder)")
 
 def hatch(args: argparse.Namespace) -> None:
-    """Hatch (run) an egg file.
-
-    Args:
-        args: Parsed command line arguments for the ``hatch`` subcommand.
-            ``args.egg`` identifies the egg file to hatch.
-
-    Returns:
-        None. Prints a placeholder message indicating an egg would hatch.
-    """
+    """Hatch (run) an egg file."""
     print(f"[hatch] Hatching {args.egg} (placeholder)")
 
 
 def main() -> None:
-    """Entry point for the ``egg`` command line interface.
-
-    Parses arguments and dispatches to the appropriate subcommand. The function
-    exits after running the selected command or printing help information.
-
-    Returns:
-        None.
-    """
+    """Entry point for the ``egg`` command line interface."""
     parser = argparse.ArgumentParser(description="Egg builder and hatcher CLI")
-
-    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers = parser.add_subparsers(dest="command")
 
     parser.add_argument(
         "--version",
@@ -56,49 +30,22 @@ def main() -> None:
     )
 
     parser_build = subparsers.add_parser("build", help="Build an egg file")
-    parser_build.add_argument(
-
-        "-m",
-        "--manifest",
-        default="manifest.yaml",
-        help="Path to manifest YAML file",
-    )
-    parser_build.add_argument(
-        "-o",
-        "--output",
-        default="out.egg",
-        help="Path for output egg file",
-    )
-    parser_build.add_argument(
-        "-f",
-        "--force",
-        action="store_true",
-        help="Overwrite output if it exists",
-    )
+    parser_build.add_argument("-m", "--manifest", default="manifest.yaml", help="Path to manifest YAML file")
+    parser_build.add_argument("-o", "--output", default="out.egg", help="Path for output egg file")
+    parser_build.add_argument("-f", "--force", action="store_true", help="Overwrite output if it exists")
     parser_build.set_defaults(func=build)
 
     parser_hatch = subparsers.add_parser("hatch", help="Hatch an egg file")
-    parser_hatch.add_argument(
-        "-e",
-        "--egg",
-        default="out.egg",
-        help="Egg file to hatch",
-    )
-    parser_hatch.add_argument(
-        "--no-sandbox",
-        action="store_true",
-        help="Run without sandbox (unsafe)",
-    )
+    parser_hatch.add_argument("-e", "--egg", default="out.egg", help="Egg file to hatch")
+    parser_hatch.add_argument("--no-sandbox", action="store_true", help="Run without sandbox (unsafe)")
     parser_hatch.set_defaults(func=hatch)
 
     args = parser.parse_args()
-
     if hasattr(args, "func"):
         args.func(args)
     else:
         parser.print_help()
-        parser.exit()
-
+        parser.exit(2)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,10 +7,9 @@ sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
 import zipfile
 
 import egg_cli  # noqa: E402
-import pytest
 
 
-def test_build(monkeypatch, tmp_path):
+def test_build(monkeypatch, tmp_path, capsys):
     output = tmp_path / "demo.egg"
     monkeypatch.setattr(
         sys,
@@ -27,10 +26,8 @@ def test_build(monkeypatch, tmp_path):
     egg_cli.main()
 
     captured = capsys.readouterr()
-    assert (
-        "[build] Building egg from manifest.yaml -> out.egg (placeholder)"
-        in captured.out
-    )
+    expected = f"[build] Building egg from examples/manifest.yaml -> {output}"
+    assert expected in captured.out
 
 
     assert output.is_file()


### PR DESCRIPTION
## Summary
- implement `egg_cli.build` using `composer.compose`
- expose `__version__` constant
- adjust CLI exit code when no subcommand
- update tests for new build output and fix `capsys` usage

## Testing
- `pip install -q .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68505585e20c8328a73d0bc4d9f62f75