### PR TITLE
Implement hashing and deterministic build

### DIFF
--- a/egg/__init__.py
+++ b/egg/__init__.py
@@ -1,5 +1,19 @@
 """egg package containing build agents for constructing egg archives."""
 
 from .composer import compose
+from .hashing import (
+    compute_hashes,
+    load_hashes,
+    sha256_file,
+    verify_hashes,
+    write_hashes_file,
+)
 
-__all__ = ["compose"]
+__all__ = [
+    "compose",
+    "compute_hashes",
+    "sha256_file",
+    "write_hashes_file",
+    "load_hashes",
+    "verify_hashes",
+]

--- a/egg/hashing.py
+++ b/egg/hashing.py
@@ -1,0 +1,50 @@
+"""Utility functions for hashing files in an egg archive."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Dict, Iterable
+
+import yaml
+
+
+_CHUNK_SIZE = 8192
+
+
+def sha256_file(path: Path) -> str:
+    """Return SHA256 hex digest of a file."""
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(_CHUNK_SIZE), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def compute_hashes(files: Iterable[Path]) -> Dict[str, str]:
+    """Compute SHA256 hashes for an iterable of files.
+
+    The resulting mapping uses each file's name as the key.
+    """
+    return {Path(f).name: sha256_file(Path(f)) for f in files}
+
+
+def write_hashes_file(hashes: Dict[str, str], path: Path) -> None:
+    """Write a mapping of file hashes to ``path`` as YAML."""
+    with open(path, "w", encoding="utf-8") as f:
+        yaml.safe_dump(hashes, f)
+
+
+def load_hashes(path: Path) -> Dict[str, str]:
+    """Load a YAML file of hashes."""
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f) or {}
+
+
+def verify_hashes(directory: Path, hashes: Dict[str, str]) -> bool:
+    """Verify that files in ``directory`` match expected ``hashes``."""
+    for name, expected in hashes.items():
+        calc = sha256_file(directory / name)
+        if calc != expected:
+            return False
+    return True

--- a/egg_cli.py
+++ b/egg_cli.py
@@ -1,4 +1,5 @@
 import argparse
+import sys
 from pathlib import Path
 from egg.composer import compose
 
@@ -83,7 +84,7 @@ def main() -> None:
     if hasattr(args, "func"):
         args.func(args)
     else:
-        parser.print_help()
+        parser.print_help(sys.stderr)
         parser.exit(2)
 
 


### PR DESCRIPTION
## Summary
- compute file hashes when composing an egg and store them in `hashes.yaml`
- use stable `ZipInfo` metadata to produce deterministic archives
- expose hashing helpers in `egg` package
- test deterministic build and hash validation
- keep CLI help printed to stderr

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685058b6fc888328910356ed7e24bf5f