### PR TITLE
Add duplicate basename check in hashing

### DIFF
--- a/egg/hashing.py
+++ b/egg/hashing.py
@@ -25,8 +25,18 @@ def compute_hashes(files: Iterable[Path]) -> Dict[str, str]:
     """Compute SHA256 hashes for an iterable of files.
 
     The resulting mapping uses each file's name as the key.
+
+    Raises:
+        ValueError: If duplicate basenames are encountered.
     """
-    return {Path(f).name: sha256_file(Path(f)) for f in files}
+    hashes: Dict[str, str] = {}
+    for f in files:
+        path = Path(f)
+        name = path.name
+        if name in hashes:
+            raise ValueError(f"Duplicate file basename: {name}")
+        hashes[name] = sha256_file(path)
+    return hashes
 
 
 def write_hashes_file(hashes: Dict[str, str], path: Path) -> None:

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -1,6 +1,8 @@
 import hashlib
 from pathlib import Path
 
+import pytest
+
 from egg.hashing import sha256_file, compute_hashes, write_hashes_file, load_hashes, verify_hashes
 
 
@@ -30,3 +32,16 @@ def test_compute_write_load_verify(tmp_path: Path) -> None:
     # corrupt a file and verification should fail
     b.write_text("X")
     assert not verify_hashes(tmp_path, loaded)
+
+
+def test_duplicate_basenames(tmp_path: Path) -> None:
+    one = tmp_path / "one"
+    two = tmp_path / "two"
+    one.mkdir()
+    two.mkdir()
+    f1 = one / "dup.txt"
+    f2 = two / "dup.txt"
+    f1.write_text("A")
+    f2.write_text("B")
+    with pytest.raises(ValueError):
+        compute_hashes([f1, f2])


### PR DESCRIPTION
## Summary
- detect duplicate file basenames in `compute_hashes`
- test error when duplicate basenames are provided

## Testing
- `pip install PyYAML -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68505cf856208328947614640c60611e