### PR TITLE
Add logging to CLI

### DIFF
--- a/egg_cli.py
+++ b/egg_cli.py
@@ -1,9 +1,13 @@
 import argparse
+import logging
 import sys
 from pathlib import Path
+
 from egg.composer import compose
 
 __version__ = "0.1.0"
+
+logger = logging.getLogger(__name__)
 
 
 def build(args: argparse.Namespace) -> None:
@@ -12,32 +16,16 @@ def build(args: argparse.Namespace) -> None:
     output = Path(args.output)
 
     if output.exists() and not args.force:
-        raise FileExistsError(f"{output} already exists. Use --force to overwrite.")
-
-    manifest = Path(args.manifest)
-    output = Path(args.output)
-
-    if output.exists() and not args.force:
         raise SystemExit(f"{output} exists. Use --force to overwrite.")
-
-    from egg import compose
 
     compose(manifest, output)
 
-    print(f"[build] Building egg from {manifest} -> {output} (placeholder)")
-
-
-def hatch(args: argparse.Namespace) -> None:
-    """Hatch (run) an egg file."""
-    print(f"[hatch] Hatching {args.egg} (placeholder)")
-    
-    compose(Path(args.manifest), Path(args.output))
-    print("[build] Building egg from manifest.yaml -> out.egg (placeholder)")
+    logger.info("[build] Building egg from %s -> %s (placeholder)", manifest, output)
 
 
 def hatch(_args: argparse.Namespace) -> None:
     """Hatch (run) an egg file."""
-    print("[hatch] Hatching egg... (placeholder)")
+    logger.info("[hatch] Hatching egg... (placeholder)")
 
 
 
@@ -51,6 +39,13 @@ def main() -> None:
         action="version",
         version=f"%(prog)s {__version__}",
         help="Show program version and exit",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="Increase verbosity. Use -vv for debug output",
     )
 
     parser_build = subparsers.add_parser("build", help="Build an egg file")
@@ -81,6 +76,15 @@ def main() -> None:
     parser_hatch.set_defaults(func=hatch)
 
     args = parser.parse_args()
+    if args.verbose >= 2:
+        level = logging.DEBUG
+    elif args.verbose == 1:
+        level = logging.INFO
+    else:
+        level = logging.WARNING
+    logging.basicConfig(level=level, format="%(message)s")
+    logging.getLogger().setLevel(level)
+
     if hasattr(args, "func"):
         args.func(args)
     else:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@ import os
 import sys
 
 import pytest
+import logging
 
 sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
 import zipfile
@@ -11,13 +12,15 @@ import yaml
 import egg_cli  # noqa: E402
 
 
-def test_build(monkeypatch, tmp_path, capsys):
+def test_build(monkeypatch, tmp_path, caplog):
     output = tmp_path / "demo.egg"
+    caplog.set_level(logging.INFO)
     monkeypatch.setattr(
         sys,
         "argv",
         [
             "egg_cli.py",
+            "--verbose",
             "build",
             "--manifest",
             os.path.join("examples", "manifest.yaml"),
@@ -27,12 +30,11 @@ def test_build(monkeypatch, tmp_path, capsys):
     )
     egg_cli.main()
 
-    captured = capsys.readouterr()
     expected = (
         f"[build] Building egg from {os.path.join('examples', 'manifest.yaml')} "
         f"-> {output} (placeholder)"
     )
-    assert expected in captured.out
+    assert expected in caplog.text
 
 
     assert output.is_file()
@@ -42,11 +44,11 @@ def test_build(monkeypatch, tmp_path, capsys):
     assert "hello.R" in names
 
 
-def test_hatch(monkeypatch, capsys):
-    monkeypatch.setattr(sys, "argv", ["egg_cli.py", "hatch"])
+def test_hatch(monkeypatch, caplog):
+    caplog.set_level(logging.INFO)
+    monkeypatch.setattr(sys, "argv", ["egg_cli.py", "--verbose", "hatch"])
     egg_cli.main()
-    captured = capsys.readouterr()
-    assert "[hatch] Hatching egg... (placeholder)" in captured.out
+    assert "[hatch] Hatching egg... (placeholder)" in caplog.text
 
 
 def test_requires_subcommand(monkeypatch):


### PR DESCRIPTION
## Summary
- refactor `egg_cli` to use `logging` instead of printing
- add `--verbose` CLI option to control log level
- adjust tests to capture log output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68505cf82f0083288f75d22cb7b74ed3