### PR TITLE
Streamline hatch CLI

### DIFF
--- a/egg_cli.py
+++ b/egg_cli.py
@@ -12,15 +12,7 @@ def build(args: argparse.Namespace) -> None:
     output = Path(args.output)
 
     if output.exists() and not args.force:
-        raise FileExistsError(f"{output} already exists. Use --force to overwrite.")
-
-    manifest = Path(args.manifest)
-    output = Path(args.output)
-
-    if output.exists() and not args.force:
         raise SystemExit(f"{output} exists. Use --force to overwrite.")
-
-    from egg import compose
 
     compose(manifest, output)
 
@@ -30,15 +22,6 @@ def build(args: argparse.Namespace) -> None:
 def hatch(args: argparse.Namespace) -> None:
     """Hatch (run) an egg file."""
     print(f"[hatch] Hatching {args.egg} (placeholder)")
-    
-    compose(Path(args.manifest), Path(args.output))
-    print("[build] Building egg from manifest.yaml -> out.egg (placeholder)")
-
-
-def hatch(_args: argparse.Namespace) -> None:
-    """Hatch (run) an egg file."""
-    print("[hatch] Hatching egg... (placeholder)")
-
 
 
 def main() -> None:
@@ -76,8 +59,17 @@ def main() -> None:
     parser_build.set_defaults(func=build)
 
     parser_hatch = subparsers.add_parser("hatch", help="Hatch an egg file")
-    parser_hatch.add_argument("-e", "--egg", default="out.egg", help="Egg file to hatch")
-    parser_hatch.add_argument("--no-sandbox", action="store_true", help="Run without sandbox (unsafe)")
+    parser_hatch.add_argument(
+        "-e",
+        "--egg",
+        default="out.egg",
+        help="Egg file to hatch",
+    )
+    parser_hatch.add_argument(
+        "--no-sandbox",
+        action="store_true",
+        help="Run without sandbox (unsafe)",
+    )
     parser_hatch.set_defaults(func=hatch)
 
     args = parser.parse_args()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,12 +1,11 @@
 import os
 import sys
-
+import hashlib
+import zipfile
+import yaml
 import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
-import zipfile
-import hashlib
-import yaml
 
 import egg_cli  # noqa: E402
 
@@ -34,7 +33,6 @@ def test_build(monkeypatch, tmp_path, capsys):
     )
     assert expected in captured.out
 
-
     assert output.is_file()
     with zipfile.ZipFile(output) as zf:
         names = zf.namelist()
@@ -46,7 +44,7 @@ def test_hatch(monkeypatch, capsys):
     monkeypatch.setattr(sys, "argv", ["egg_cli.py", "hatch"])
     egg_cli.main()
     captured = capsys.readouterr()
-    assert "[hatch] Hatching egg... (placeholder)" in captured.out
+    assert "[hatch] Hatching out.egg (placeholder)" in captured.out
 
 
 def test_requires_subcommand(monkeypatch):
@@ -117,4 +115,3 @@ def test_deterministic_build(monkeypatch, tmp_path):
     egg_cli.main()
 
     assert out1.read_bytes() == out2.read_bytes()
-

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -1,7 +1,13 @@
 import hashlib
 from pathlib import Path
 
-from egg.hashing import sha256_file, compute_hashes, write_hashes_file, load_hashes, verify_hashes
+from egg.hashing import (
+    compute_hashes,
+    load_hashes,
+    sha256_file,
+    verify_hashes,
+    write_hashes_file,
+)
 
 
 def test_sha256_file(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- consolidate duplicated hatch functions
- simplify build path handling
- update tests for new CLI

## Testing
- `ruff check .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68505cf70ca48328a197c8f86414827a