### PR TITLE
Fix nondeterministic YAML output

### DIFF
--- a/egg/hashing.py
+++ b/egg/hashing.py
@@ -41,8 +41,12 @@ def compute_hashes(files: Iterable[Path]) -> Dict[str, str]:
 
 def write_hashes_file(hashes: Dict[str, str], path: Path) -> None:
     """Write a mapping of file hashes to ``path`` as YAML."""
+    # ``yaml.safe_dump`` does not guarantee deterministic key order unless
+    # ``sort_keys`` is explicitly set.  Relying on the default can result in
+    # nondeterministic builds across PyYAML versions.  Explicitly enable key
+    # sorting so the output is stable regardless of environment.
     with open(path, "w", encoding="utf-8") as f:
-        yaml.safe_dump(hashes, f)
+        yaml.safe_dump(hashes, f, sort_keys=True)
 
 
 def load_hashes(path: Path) -> Dict[str, str]:


### PR DESCRIPTION
## Summary
- ensure hashes.yaml is generated deterministically

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68505e7a485883288f51748517228fad