### PR TITLE
Fix PyYAML import errors

### DIFF
--- a/egg/composer.py
+++ b/egg/composer.py
@@ -8,7 +8,12 @@ import zipfile
 from pathlib import Path
 from typing import Iterable, List
 
-import yaml
+try:
+    import yaml
+except ModuleNotFoundError as exc:  # pragma: no cover - import guard
+    raise ModuleNotFoundError(
+        "PyYAML is required to use egg composer. Install with 'pip install PyYAML'"
+    ) from exc
 
 from .hashing import compute_hashes, write_hashes_file
 

--- a/egg/manifest.py
+++ b/egg/manifest.py
@@ -4,7 +4,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import List
 
-import yaml
+try:
+    import yaml
+except ModuleNotFoundError as exc:  # pragma: no cover - import guard
+    raise ModuleNotFoundError(
+        "PyYAML is required to load egg manifests. Install with 'pip install PyYAML'"
+    ) from exc
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- catch missing PyYAML at import time for composer and manifest modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68505ff7a01883289ced7e3625dedb9e