### PR TITLE
Remove Black formatting step from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pytest flake8 black
-    - name: Format code with Black
-      run: |
-        black .
     - name: Commit formatted code
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- drop the "Format code with Black" step in the CI workflow so it won't try to reformat and push

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685062f0b2448328b434d199b4b17317