### PR TITLE
Fix linting errors

### DIFF
--- a/egg_cli.py
+++ b/egg_cli.py
@@ -28,7 +28,6 @@ def hatch(_args: argparse.Namespace) -> None:
     logger.info("[hatch] Hatching egg... (placeholder)")
 
 
-
 def main(argv: list[str] | None = None) -> None:
     """Entry point for the ``egg`` command line interface."""
     if argv is None:  # pragma: no cover - convenience for __main__
@@ -78,8 +77,12 @@ def main(argv: list[str] | None = None) -> None:
     parser_build.set_defaults(func=build)
 
     parser_hatch = subparsers.add_parser("hatch", help="Hatch an egg file")
-    parser_hatch.add_argument("-e", "--egg", default="out.egg", help="Egg file to hatch")
-    parser_hatch.add_argument("--no-sandbox", action="store_true", help="Run without sandbox (unsafe)")
+    parser_hatch.add_argument(
+        "-e", "--egg", default="out.egg", help="Egg file to hatch"
+    )
+    parser_hatch.add_argument(
+        "--no-sandbox", action="store_true", help="Run without sandbox (unsafe)"
+    )
     parser_hatch.set_defaults(func=hatch)
 
     args, remaining = parser.parse_known_args(argv)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,14 +1,12 @@
 import os
 import sys
-
+import zipfile
+import hashlib
+import yaml
 import pytest
 import logging
 
 sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
-import zipfile
-import hashlib
-import yaml
-
 import egg_cli  # noqa: E402
 
 
@@ -35,7 +33,6 @@ def test_build(monkeypatch, tmp_path, caplog):
         f"-> {output} (placeholder)"
     )
     assert expected in caplog.text
-
 
     assert output.is_file()
     with zipfile.ZipFile(output) as zf:
@@ -140,4 +137,3 @@ def test_deterministic_build(monkeypatch, tmp_path):
     egg_cli.main()
 
     assert out1.read_bytes() == out2.read_bytes()
-

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -3,7 +3,13 @@ from pathlib import Path
 
 import pytest
 
-from egg.hashing import sha256_file, compute_hashes, write_hashes_file, load_hashes, verify_hashes
+from egg.hashing import (
+    sha256_file,
+    compute_hashes,
+    write_hashes_file,
+    load_hashes,
+    verify_hashes,
+)
 
 
 def test_sha256_file(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- tweak CLI options formatting
- reorder imports in tests and format

## Testing
- `flake8`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685064af37c48328bdc00400460f44d6