### PR TITLE
Add verification subcommand and archive check

### DIFF
--- a/egg/__init__.py
+++ b/egg/__init__.py
@@ -5,6 +5,7 @@ from .hashing import (
     compute_hashes,
     load_hashes,
     sha256_file,
+    verify_archive,
     verify_hashes,
     write_hashes_file,
 )
@@ -16,4 +17,5 @@ __all__ = [
     "write_hashes_file",
     "load_hashes",
     "verify_hashes",
+    "verify_archive",
 ]

--- a/egg_cli.py
+++ b/egg_cli.py
@@ -4,6 +4,7 @@ import sys
 from pathlib import Path
 
 from egg.composer import compose
+from egg.hashing import verify_archive
 
 __version__ = "0.1.0"
 
@@ -26,6 +27,17 @@ def build(args: argparse.Namespace) -> None:
 def hatch(_args: argparse.Namespace) -> None:
     """Hatch (run) an egg file."""
     logger.info("[hatch] Hatching egg... (placeholder)")
+
+
+def verify(args: argparse.Namespace) -> None:
+    """Verify that an egg archive matches its recorded hashes."""
+    egg_path = Path(args.egg)
+    if not egg_path.is_file():
+        raise SystemExit(f"Egg file not found: {egg_path}")
+    if verify_archive(egg_path):
+        logger.info("[verify] %s verified successfully", egg_path)
+    else:
+        raise SystemExit("Hash verification failed")
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -84,6 +96,15 @@ def main(argv: list[str] | None = None) -> None:
         "--no-sandbox", action="store_true", help="Run without sandbox (unsafe)"
     )
     parser_hatch.set_defaults(func=hatch)
+
+    parser_verify = subparsers.add_parser("verify", help="Verify an egg archive")
+    parser_verify.add_argument(
+        "-e",
+        "--egg",
+        default="out.egg",
+        help="Egg file to verify",
+    )
+    parser_verify.set_defaults(func=verify)
 
     args, remaining = parser.parse_known_args(argv)
     if remaining:


### PR DESCRIPTION
## Summary
- add `verify_archive` helper to check archived file hashes
- expose new helper in package `__all__`
- implement `egg verify` CLI subcommand
- test verification command and failure case

## Testing
- `pip install PyYAML`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850664a96d08328a3d8e7b04a216bde