### PR TITLE
Add manifest type validation

### DIFF
--- a/egg/manifest.py
+++ b/egg/manifest.py
@@ -47,6 +47,12 @@ def load_manifest(path: Path | str) -> Manifest:
         if field not in data:
             raise ValueError(f"Missing required field: {field}")
 
+    # Validate simple scalar fields
+    if not isinstance(data["name"], str):
+        raise ValueError("'name' must be a string")
+    if not isinstance(data["description"], str):
+        raise ValueError("'description' must be a string")
+
     cells_data = data["cells"]
     if not isinstance(cells_data, list):
         raise ValueError("'cells' must be a list")
@@ -57,6 +63,10 @@ def load_manifest(path: Path | str) -> Manifest:
             raise ValueError(f"Cell #{i} must be a mapping")
         if "language" not in cell or "source" not in cell:
             raise ValueError("Each cell requires 'language' and 'source'")
+        if not isinstance(cell["language"], str):
+            raise ValueError(f"Cell #{i} 'language' must be a string")
+        if not isinstance(cell["source"], str):
+            raise ValueError(f"Cell #{i} 'source' must be a string")
         cells.append(Cell(language=cell["language"], source=cell["source"]))
 
     return Manifest(name=data["name"], description=data["description"], cells=cells)

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -49,3 +49,66 @@ cells:
     )  # source missing in cell
     with pytest.raises(ValueError):
         load_manifest(path)
+
+
+def test_invalid_name_type(tmp_path: Path):
+    path = tmp_path / "bad_name.yaml"
+    path.write_text(
+        """
+name:
+  - not a string
+description: desc
+cells:
+  - language: python
+    source: hello.py
+"""
+    )
+    with pytest.raises(ValueError):
+        load_manifest(path)
+
+
+def test_invalid_description_type(tmp_path: Path):
+    path = tmp_path / "bad_desc.yaml"
+    path.write_text(
+        """
+name: Example
+description:
+  key: value
+cells:
+  - language: python
+    source: hello.py
+"""
+    )
+    with pytest.raises(ValueError):
+        load_manifest(path)
+
+
+def test_invalid_cell_language_type(tmp_path: Path):
+    path = tmp_path / "bad_cell_lang.yaml"
+    path.write_text(
+        """
+name: Example
+description: desc
+cells:
+  - language: [python]
+    source: hello.py
+"""
+    )
+    with pytest.raises(ValueError):
+        load_manifest(path)
+
+
+def test_invalid_cell_source_type(tmp_path: Path):
+    path = tmp_path / "bad_cell_source.yaml"
+    path.write_text(
+        """
+name: Example
+description: desc
+cells:
+  - language: python
+    source:
+      - hello.py
+"""
+    )
+    with pytest.raises(ValueError):
+        load_manifest(path)


### PR DESCRIPTION
## Summary
- validate manifest name and description types
- ensure each cell's language and source values are strings
- test invalid types for manifest fields and cells

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685067e812b08328b6f46c824e1a7447