### PR TITLE
Check for extra files in verify_archive

### DIFF
--- a/egg/hashing.py
+++ b/egg/hashing.py
@@ -95,4 +95,10 @@ def verify_archive(archive: Path) -> bool:
             if hashlib.sha256(data).hexdigest() != expected:
                 return False
 
+        # Ensure no unverified files are present in the archive
+        names = set(zf.namelist())
+        names.discard("hashes.yaml")
+        if names != set(hashes.keys()):
+            return False
+
     return True


### PR DESCRIPTION
## Summary
- verify that all files listed in `hashes.yaml` match the archive contents
- ensure no extra files are present in archives
- test `verify_archive` behaviour with extra files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685067e5e1a48328996422e624a3aab3