### PR TITLE
Ignore E501 in flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 88
-extend-ignore = E203
+extend-ignore = E203,E501
 


### PR DESCRIPTION
## Summary
- allow long lines by ignoring E501 in flake8 config

## Testing
- `flake8 && black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685068c6590c8328bcdca43286f72434