### PR TITLE
Fix commit formatting step in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,11 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        if [ -n "$(git status --porcelain)" ]; then
-          git config user.name "GitHub Actions"
-          git config user.email "actions@github.com"
-          git commit -am "chore: format with black"
-          git push
-        fi
+        black .
+        git config user.name "GitHub Actions"
+        git config user.email "actions@github.com"
+        git commit -am "chore: format with black" || echo "No changes to commit"
+        git push
     - name: Lint
       run: |
         flake8


### PR DESCRIPTION
## Summary
- run `black` unconditionally in the CI formatting step

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68506be7cab88328ab8f12cfefb29267