### PR TITLE
Fix CI commit formatting condition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
         pip install pytest flake8 black
         pip install -e .
     - name: Commit formatted code
+      if: github.event_name == 'push'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |


### PR DESCRIPTION
## Summary
- run the automatic format commit only on pushes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68506dee12d0832882cf1b7c7b15d05c