### PR TITLE
Enforce CLI subcommand with argparse

### DIFF
--- a/egg_cli.py
+++ b/egg_cli.py
@@ -90,7 +90,7 @@ def main(argv: list[str] | None = None) -> None:
         description="Egg builder and hatcher CLI",
         parents=[global_parser],
     )
-    subparsers = parser.add_subparsers(dest="command")
+    subparsers = parser.add_subparsers(dest="command", required=True)
 
     parser_build = subparsers.add_parser("build", help="Build an egg file")
 
@@ -146,11 +146,7 @@ def main(argv: list[str] | None = None) -> None:
     logging.basicConfig(level=level, format="%(message)s")
     logging.getLogger().setLevel(level)
 
-    if hasattr(args, "func"):
-        args.func(args)
-    else:
-        parser.print_help(sys.stderr)
-        parser.exit(2)
+    args.func(args)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -82,17 +82,21 @@ def test_hatch(monkeypatch, tmp_path, caplog):
     assert f"[hatch] Completed running {egg_path}" in caplog.text
 
 
-def test_requires_subcommand(monkeypatch):
+def test_requires_subcommand(monkeypatch, capsys):
     monkeypatch.setattr(sys, "argv", ["egg_cli.py"])
     with pytest.raises(SystemExit) as exc:
         egg_cli.main()
     assert exc.value.code == 2
+    captured = capsys.readouterr()
+    assert "the following arguments are required: command" in captured.err
 
 
 def test_help_without_subcommand(monkeypatch, capsys):
     monkeypatch.setattr(sys, "argv", ["egg_cli.py"])
     with pytest.raises(SystemExit):
         egg_cli.main()
+    out = capsys.readouterr().err
+    assert out.startswith("usage:")
 
 
 def test_build_missing_source(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- require explicit subcommand in CLI
- simplify CLI dispatch code
- expect argparse error text in tests when no subcommand provided

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685070e9d9248328b19b8fd6f018e61a