### PR TITLE
Fix build log message

### DIFF
--- a/egg_cli.py
+++ b/egg_cli.py
@@ -35,7 +35,7 @@ def build(args: argparse.Namespace) -> None:
     if not verify_archive(output):
         raise SystemExit("Hash verification failed")
 
-    logger.info("[build] Building egg from %s -> %s (placeholder)", manifest, output)
+    logger.info("[build] Building egg from %s -> %s", manifest, output)
 
 
 def hatch(args: argparse.Namespace) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,7 +32,7 @@ def test_build(monkeypatch, tmp_path, caplog):
 
     expected = (
         f"[build] Building egg from {os.path.join('examples', 'manifest.yaml')} "
-        f"-> {output} (placeholder)"
+        f"-> {output}"
     )
     assert expected in caplog.text
 


### PR DESCRIPTION
## Summary
- remove the `(placeholder)` suffix from build log output
- update test to expect new build log text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685074d1ec248328b3b7a7612a9cbbd3