### PR TITLE
Warn when hatching without sandbox

### DIFF
--- a/egg_cli.py
+++ b/egg_cli.py
@@ -46,6 +46,11 @@ def hatch(args: argparse.Namespace) -> None:
     if not verify_archive(egg_path):
         raise SystemExit("Hash verification failed")
 
+    if not args.no_sandbox:
+        logger.warning(
+            "[hatch] Sandboxing is not yet implemented; running without isolation"
+        )
+
     with zipfile.ZipFile(egg_path) as zf, tempfile.TemporaryDirectory() as tmpdir:
         zf.extractall(tmpdir)
         manifest_path = Path(tmpdir) / "manifest.yaml"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -81,6 +81,7 @@ def test_hatch(monkeypatch, tmp_path, caplog):
     )
     assert any(cmd[0] == "Rscript" and cmd[1].endswith("hello.R") for cmd in calls)
     assert f"[hatch] Completed running {egg_path}" in caplog.text
+    assert "Sandboxing is not yet implemented" in caplog.text
 
 
 def test_hatch_bash(monkeypatch, tmp_path, caplog):


### PR DESCRIPTION
## Summary
- check `args.no_sandbox` in `hatch`
- warn that sandboxing isn't implemented when flag absent
- verify warning via CLI tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685074d079448328a502b78bde6a7c3c