### PR TITLE
Validate manifest fields

### DIFF
--- a/egg/manifest.py
+++ b/egg/manifest.py
@@ -43,9 +43,15 @@ def load_manifest(path: Path | str) -> Manifest:
     if not isinstance(data, dict):
         raise ValueError("Manifest root must be a mapping")
 
-    for field in ("name", "description", "cells"):
+    required_fields = {"name", "description", "cells"}
+    for field in required_fields:
         if field not in data:
             raise ValueError(f"Missing required field: {field}")
+
+    unknown_fields = set(data) - required_fields
+    if unknown_fields:
+        unknown = ", ".join(sorted(unknown_fields))
+        raise ValueError(f"Unknown field(s): {unknown}")
 
     # Validate simple scalar fields
     if not isinstance(data["name"], str):

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -112,3 +112,19 @@ cells:
     )
     with pytest.raises(ValueError):
         load_manifest(path)
+
+
+def test_unknown_root_field(tmp_path: Path) -> None:
+    path = tmp_path / "extra.yaml"
+    path.write_text(
+        """
+name: Example
+description: desc
+cells:
+  - language: python
+    source: hello.py
+extra: value
+"""
+    )
+    with pytest.raises(ValueError):
+        load_manifest(path)


### PR DESCRIPTION
## Summary
- detect unknown fields in manifest when loading
- test error on an unexpected manifest field

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685074ceec648328bf9823a1be4b01ce