### PR TITLE
Add PyYAML import guard in hashing

### DIFF
--- a/egg/hashing.py
+++ b/egg/hashing.py
@@ -9,7 +9,12 @@ from typing import Dict, Iterable
 
 import zipfile
 
-import yaml
+try:
+    import yaml
+except ModuleNotFoundError as exc:  # pragma: no cover - import guard
+    raise ModuleNotFoundError(
+        "PyYAML is required for egg hashing. Install with 'pip install PyYAML'"
+    ) from exc
 
 
 _CHUNK_SIZE = 8192


### PR DESCRIPTION
## Summary
- handle PyYAML absence in `egg.hashing`
- test the hashing import guard

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685078e573ac8328ad3fdd34eb49690e