### PR TITLE
Add chunker utility and tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ agents are implemented in this prototype.  They live in
   - Hashes all blobs, signs the manifest for audit/provenance.
 - **Chunker/Index Agent**
   - Builds static trunk, offset tables, and "heap of heaps" structure.
+  - Splits archives into fixed-size chunks and records offsets for deterministic indexing.
 - **Precompute Agent**
   - Optionally runs code to precompute cell outputs for instant preview.
 - **Test Agent**

--- a/egg/chunker.py
+++ b/egg/chunker.py
@@ -1,6 +1,38 @@
-"""Placeholder chunker agent."""
+"""Chunker agent for splitting files into deterministic segments."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List
 
 
-def chunk(_path: str) -> None:
-    """Placeholder function for future chunking logic."""
-    pass
+def chunk(path: Path | str, *, chunk_size: int = 1_048_576) -> List[Dict[str, int]]:
+    """Divide ``path`` into ``chunk_size`` byte blocks.
+
+    Parameters
+    ----------
+    path : Path | str
+        File to chunk.
+    chunk_size : int, optional
+        Size of each chunk in bytes. Defaults to ``1_048_576`` (1 MiB).
+
+    Returns
+    -------
+    List[Dict[str, int]]
+        List of ``{"offset": int, "size": int}`` metadata for each chunk in the
+        order they appear in the file.
+    """
+
+    file_path = Path(path)
+    metadata: List[Dict[str, int]] = []
+    offset = 0
+    with open(file_path, "rb") as f:
+        while True:
+            data = f.read(chunk_size)
+            if not data:
+                break
+            size = len(data)
+            metadata.append({"offset": offset, "size": size})
+            offset += size
+    return metadata
+

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -1,0 +1,26 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+
+from egg.chunker import chunk
+
+
+def test_chunk_deterministic(tmp_path: Path) -> None:
+    data = b"abcdefghij"  # 10 bytes
+    f = tmp_path / "data.bin"
+    f.write_bytes(data)
+
+    expected = [
+        {"offset": 0, "size": 4},
+        {"offset": 4, "size": 4},
+        {"offset": 8, "size": 2},
+    ]
+
+    first = chunk(f, chunk_size=4)
+    second = chunk(f, chunk_size=4)
+    assert first == expected
+    assert second == expected
+
+


### PR DESCRIPTION
## Summary
- implement `chunk` function in `egg/chunker.py` to produce offset/size metadata
- describe chunker role in `AGENTS.md`
- test deterministic chunking

## Testing
- `pip install PyYAML -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68507a439d2c832894cf3df72e439a76