### PR TITLE
Validate manifest source paths

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -299,6 +299,36 @@ def test_build_missing_manifest(monkeypatch, tmp_path):
     assert str(manifest) in str(exc.value)
 
 
+def test_build_rejects_unsafe_path(monkeypatch, tmp_path):
+    manifest_dir = tmp_path / "sub"
+    manifest_dir.mkdir()
+    manifest = manifest_dir / "manifest.yaml"
+    manifest.write_text(
+        """
+name: Example
+description: desc
+cells:
+  - language: python
+    source: ../evil.py
+"""
+    )
+    output = tmp_path / "demo.egg"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "egg_cli.py",
+            "build",
+            "--manifest",
+            str(manifest),
+            "--output",
+            str(output),
+        ],
+    )
+    with pytest.raises(ValueError):
+        egg_cli.main()
+
+
 def test_version_option(monkeypatch, capsys):
     monkeypatch.setattr(sys, "argv", ["egg_cli.py", "--version"])
     with pytest.raises(SystemExit):

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -128,3 +128,36 @@ extra: value
     )
     with pytest.raises(ValueError):
         load_manifest(path)
+
+
+def test_source_outside_manifest_dir(tmp_path: Path) -> None:
+    """Paths escaping the manifest directory should be rejected."""
+    manifest_dir = tmp_path / "nested"
+    manifest_dir.mkdir()
+    path = manifest_dir / "manifest.yaml"
+    path.write_text(
+        """
+name: Example
+description: desc
+cells:
+  - language: python
+    source: ../evil.py
+"""
+    )
+    with pytest.raises(ValueError):
+        load_manifest(path)
+
+
+def test_source_absolute_path(tmp_path: Path) -> None:
+    path = tmp_path / "manifest.yaml"
+    path.write_text(
+        """
+name: Example
+description: desc
+cells:
+  - language: python
+    source: /abs.py
+"""
+    )
+    with pytest.raises(ValueError):
+        load_manifest(path)


### PR DESCRIPTION
## Summary
- enforce safe source paths in composer and manifest loader
- reject manifest paths outside manifest directory
- test CLI and manifest validations for unsafe paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68507a41c2e88328a36301f7685624e8