### PR TITLE
Add `info` subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,13 @@ pip install .
 ## Usage
 
 After installation the `egg` command becomes available. The CLI currently
-provides three subcommands:
+provides four subcommands:
 
 ```bash
 egg build --manifest <file> --output <egg> [--force]
 egg hatch --egg <egg> [--no-sandbox]
 egg verify --egg <egg>
+egg info --egg <egg>
 ```
 
 Use `egg <command> -h` to see all options.
@@ -84,6 +85,12 @@ Below is a minimal walkthrough using the placeholder implementation:
 
    ```bash
    egg verify --egg demo.egg
+   ```
+
+5. Inspect the archive metadata:
+
+   ```bash
+   egg info --egg demo.egg
    ```
 
 The builder reads `manifest.yaml`, copies the referenced source files and writes

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -561,3 +561,36 @@ cells:
         names = set(zf.namelist())
     assert "a/hello.py" in names
     assert "b/hello.py" in names
+
+
+def test_info_subcommand(monkeypatch, tmp_path, capsys):
+    """The info command should print manifest details."""
+    egg_path = tmp_path / "demo.egg"
+
+    # build an egg
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "egg_cli.py",
+            "build",
+            "--manifest",
+            os.path.join("examples", "manifest.yaml"),
+            "--output",
+            str(egg_path),
+        ],
+    )
+    egg_cli.main()
+    capsys.readouterr()  # clear build output
+
+    # run info
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["egg_cli.py", "info", "--egg", str(egg_path)],
+    )
+    egg_cli.main()
+    out = capsys.readouterr().out
+    assert "Demo Notebook" in out
+    assert "hello.py" in out
+    assert "hello.R" in out


### PR DESCRIPTION
## Summary
- implement `egg info` subcommand to display archive metadata
- document new command in README
- test new info command output

## Testing
- `pip install .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68507a42ba3483289470a5203610fc0c