### PR TITLE
Add runtime command env overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ egg verify --egg <egg>
 
 Use `egg <command> -h` to see all options.
 
+### Runtime Command Overrides
+
+The commands used for each cell language during `egg hatch` can be
+customized via environment variables. Set `EGG_CMD_PYTHON`,
+`EGG_CMD_R`, or `EGG_CMD_BASH` to the path of the desired executable to
+override the defaults.
+
+```bash
+EGG_CMD_PYTHON=/opt/python3/bin/python egg hatch --egg demo.egg
+```
+
 ### Example Build Walkthrough
 
 Below is a minimal walkthrough using the placeholder implementation:


### PR DESCRIPTION
## Summary
- allow overriding runtime commands via env vars in `egg_cli.py`
- document env vars in README
- test custom command overrides during hatch

## Testing
- `pip install -q .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68507a43810c8328b7b17b502cf267d6