### PR TITLE
Fix flake8 import warning

### DIFF
--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -3,7 +3,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
-from egg.chunker import chunk
+from egg.chunker import chunk  # noqa: E402
 
 
 def test_chunk_deterministic(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- silence flake8 E402 in test_chunker

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68507d142b108328906ca6d050094d85