### PR TITLE
Validate chunk size

### DIFF
--- a/egg/chunker.py
+++ b/egg/chunker.py
@@ -23,6 +23,9 @@ def chunk(path: Path | str, *, chunk_size: int = 1_048_576) -> List[Dict[str, in
         order they appear in the file.
     """
 
+    if chunk_size <= 0:
+        raise ValueError("chunk_size must be positive")
+
     file_path = Path(path)
     metadata: List[Dict[str, int]] = []
     offset = 0

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -3,6 +3,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+import pytest
 from egg.chunker import chunk  # noqa: E402
 
 
@@ -21,3 +22,17 @@ def test_chunk_deterministic(tmp_path: Path) -> None:
     second = chunk(f, chunk_size=4)
     assert first == expected
     assert second == expected
+
+
+def test_chunk_invalid_size_zero(tmp_path: Path) -> None:
+    f = tmp_path / "data.bin"
+    f.write_bytes(b"hi")
+    with pytest.raises(ValueError):
+        chunk(f, chunk_size=0)
+
+
+def test_chunk_invalid_size_negative(tmp_path: Path) -> None:
+    f = tmp_path / "data.bin"
+    f.write_bytes(b"hi")
+    with pytest.raises(ValueError):
+        chunk(f, chunk_size=-1)


### PR DESCRIPTION
## Summary
- ensure chunk_size is >0 in chunker
- test chunker with invalid chunk sizes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68507eccc2888328a172496af7e63466