### PR TITLE
Add _is_relative_to helper

### DIFF
--- a/egg/composer.py
+++ b/egg/composer.py
@@ -8,6 +8,8 @@ import zipfile
 from pathlib import Path
 from typing import Iterable, List
 
+from .utils import _is_relative_to
+
 try:
     import yaml
 except ModuleNotFoundError as exc:  # pragma: no cover - import guard
@@ -43,7 +45,7 @@ def _normalize_source(path: str | Path, manifest_dir: Path) -> Path:
         raise ValueError(f"Absolute source paths are not allowed: {path}")
     manifest_dir = manifest_dir.resolve()
     abs_path = (manifest_dir / p).resolve(strict=False)
-    if not abs_path.is_relative_to(manifest_dir):
+    if not _is_relative_to(abs_path, manifest_dir):
         raise ValueError(f"Source path escapes manifest directory: {path}")
     return abs_path.relative_to(manifest_dir)
 

--- a/egg/manifest.py
+++ b/egg/manifest.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import List
 
+from .utils import _is_relative_to
+
 try:
     import yaml
 except ModuleNotFoundError as exc:  # pragma: no cover - import guard
@@ -32,7 +34,7 @@ def _normalize_source(path: str | Path, manifest_dir: Path) -> str:
         raise ValueError(f"Absolute source paths are not allowed: {path}")
     manifest_dir = manifest_dir.resolve()
     abs_path = (manifest_dir / p).resolve(strict=False)
-    if not abs_path.is_relative_to(manifest_dir):
+    if not _is_relative_to(abs_path, manifest_dir):
         raise ValueError(f"Source path escapes manifest directory: {path}")
     return abs_path.relative_to(manifest_dir).as_posix()
 

--- a/egg/utils.py
+++ b/egg/utils.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _is_relative_to(path: Path, base: Path) -> bool:
+    """Return True if *path* is relative to *base*.
+
+    This provides a backport of ``Path.is_relative_to`` for Python 3.8.
+    """
+    try:
+        path.relative_to(base)
+        return True
+    except ValueError:
+        return False


### PR DESCRIPTION
## Summary
- add a small path helper to backport `Path.is_relative_to`
- use this helper in the composer and manifest modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68507ec91efc8328b80faf2a23b55b6c