### PR TITLE
Add env-signing key support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ override the defaults.
 EGG_CMD_PYTHON=/opt/python3/bin/python egg hatch --egg demo.egg
 ```
 
+### Signing Key
+
+The HMAC signature for `hashes.yaml` defaults to a built-in key. Set
+`EGG_SIGNING_KEY` to override this value when building and verifying egg
+files.
+
+```bash
+EGG_SIGNING_KEY=mysecret egg build --manifest examples/manifest.yaml --output demo.egg
+```
+
 ### Example Build Walkthrough
 
 Below is a minimal walkthrough using the placeholder implementation:


### PR DESCRIPTION
## Summary
- read `EGG_SIGNING_KEY` for the archive signing key
- allow overriding signing key via environment variable when signing or verifying
- document the variable in the README
- test `EGG_SIGNING_KEY` behaviour

## Testing
- `pip install PyYAML`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68507ecbf9d483289e6eb98c99f65c13