### PR TITLE
Enable coverage in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest flake8 black
+        pip install pytest flake8 black coverage
         pip install -e .
     - name: Commit formatted code
       if: github.event_name == 'push'
@@ -39,4 +39,10 @@ jobs:
         black --check .
     - name: Run tests
       run: |
-        pytest -q
+        coverage run -m pytest -q
+        coverage xml
+    - name: Upload coverage
+      uses: actions/upload-artifact@v3
+      with:
+        name: coverage-xml
+        path: coverage.xml


### PR DESCRIPTION
## Summary
- run tests with coverage in CI
- upload coverage.xml as a build artifact

## Testing
- `coverage run -m pytest -q`
- `coverage xml`

------
https://chatgpt.com/codex/tasks/task_e_685080ec1c0483288b32e708dcbe1625