### PR TITLE
Add coverage to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest flake8 black
+        pip install pytest pytest-cov flake8 black
         pip install -e .
     - name: Commit formatted code
       if: github.event_name == 'push'
@@ -37,6 +37,11 @@ jobs:
       run: |
         flake8
         black --check .
-    - name: Run tests
+    - name: Run tests with coverage
       run: |
-        pytest -q
+        pytest --cov=egg --cov=egg_cli --cov-report=xml \
+               --cov-report=term-missing:skip-covered -q
+    - uses: codecov/codecov-action@v3
+      with:
+        files: coverage.xml
+        fail_ci_if_error: true

--- a/README.md
+++ b/README.md
@@ -126,8 +126,9 @@ roadmap.
 
 Install dependencies using `pip install .` (or `pip install -e .`) so that
 packages like PyYAML are available. Then run `pytest` to execute the test
-suite. You can also check formatting or style with tools like `ruff` or
-`black`.
+suite. To check coverage, install `pytest-cov` and run
+`pytest --cov=egg --cov=egg_cli`. You can also check formatting or style with
+tools like `ruff` or `black`.
 
 ## Citation
 


### PR DESCRIPTION
## Summary
- run pytest with coverage reporting
- upload `coverage.xml` to Codecov
- document running tests with coverage in the README

## Testing
- `pytest -q`
- `pytest --cov=egg --cov=egg_cli --cov-report=xml --cov-report=term-missing:skip-covered -q`

------
https://chatgpt.com/codex/tasks/task_e_6850843b91ac83288446f2ac58813b5e