### PR TITLE
Add pylint reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest pytest-cov flake8 black
+        pip install pytest pytest-cov flake8 black pylint
         pip install -e .
     - name: Commit formatted code
       if: github.event_name == 'push'
@@ -37,6 +37,10 @@ jobs:
       run: |
         flake8
         black --check .
+    - name: Pylint
+      continue-on-error: true
+      run: |
+        pylint egg egg_cli.py
     - name: Run tests with coverage
       run: |
         pytest --cov=egg --cov=egg_cli --cov-report=xml \


### PR DESCRIPTION
## Summary
- include pylint in CI dependencies
- run pylint in CI but continue the build if it fails

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850850f93488328bdfc3cd6846bc397