### PR TITLE
Fix Codecov rate limit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,5 @@ jobs:
       with:
         files: coverage.xml
         fail_ci_if_error: true
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- set `CODECOV_TOKEN` in CI to avoid rate limit failures

## Testing
- `flake8`
- `black --check .`
- `pytest --cov=egg --cov=egg_cli --cov-report=xml --cov-report=term-missing:skip-covered -q`

------
https://chatgpt.com/codex/tasks/task_e_685085560c948328a8f2fdfb76c52f26