### PR TITLE
Add missing docstrings

### DIFF
--- a/egg/manifest.py
+++ b/egg/manifest.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+"""Data structures and helpers for reading ``manifest.yaml`` files."""
+
 from dataclasses import dataclass
 from pathlib import Path
 from typing import List
@@ -16,12 +18,16 @@ except ModuleNotFoundError as exc:  # pragma: no cover - import guard
 
 @dataclass
 class Cell:
+    """A single code cell entry in the manifest."""
+
     language: str
     source: str
 
 
 @dataclass
 class Manifest:
+    """Top-level manifest describing the notebook cells."""
+
     name: str
     description: str
     cells: List[Cell]

--- a/egg/utils.py
+++ b/egg/utils.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from pathlib import Path
+"""Utility helpers used across the egg codebase."""
 
+from pathlib import Path
 
 def _is_relative_to(path: Path, base: Path) -> bool:
     """Return True if *path* is relative to *base*.

--- a/egg_cli.py
+++ b/egg_cli.py
@@ -1,3 +1,5 @@
+"""Command line interface for building and running egg archives."""
+
 import argparse
 import logging
 import os

--- a/examples/hello.py
+++ b/examples/hello.py
@@ -1,1 +1,3 @@
+"""Example Python cell for the demo manifest."""
+
 print("Hello from Python")


### PR DESCRIPTION
## Summary
- add module level docstrings to utils, manifest and CLI modules
- document Cell and Manifest dataclasses
- add docstring to example Python cell

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68508758bcb483288fcb13ded683a631