### PR TITLE
Add runtime fetcher agent

### DIFF
--- a/egg/runtime_fetcher.py
+++ b/egg/runtime_fetcher.py
@@ -1,0 +1,73 @@
+"""Agent for fetching interpreter/runtime blocks referenced in a manifest."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import List
+
+from .utils import _is_relative_to
+
+try:
+    import yaml
+except ModuleNotFoundError as exc:  # pragma: no cover - import guard
+    raise ModuleNotFoundError(
+        "PyYAML is required to use the runtime fetcher. Install with 'pip install PyYAML'"
+    ) from exc
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_runtime_blocks(manifest_path: Path | str) -> List[Path]:
+    """Return absolute paths to runtime dependencies listed in ``manifest_path``.
+
+    Currently only local file paths listed under a ``dependencies`` field are
+    supported. Each path must be relative to the manifest directory and must
+    exist on disk.
+
+    Parameters
+    ----------
+    manifest_path : Path | str
+        Path to the manifest YAML file.
+
+    Returns
+    -------
+    List[Path]
+        Absolute paths to the dependency files.
+
+    Raises
+    ------
+    FileNotFoundError
+        If a dependency path does not exist.
+    ValueError
+        If dependency paths are absolute or escape the manifest directory.
+    """
+
+    manifest_path = Path(manifest_path)
+    with open(manifest_path, "r", encoding="utf-8") as f:
+        manifest = yaml.safe_load(f) or {}
+
+    deps = manifest.get("dependencies", [])
+    if deps is None:
+        return []
+    if not isinstance(deps, list):
+        raise ValueError("'dependencies' must be a list")
+
+    manifest_dir = manifest_path.parent.resolve()
+    resolved: List[Path] = []
+
+    for dep in deps:
+        if not isinstance(dep, str):
+            raise ValueError("dependency entries must be strings")
+        p = Path(dep)
+        if p.is_absolute():
+            raise ValueError(f"Absolute dependency paths are not allowed: {dep}")
+        abs_path = (manifest_dir / p).resolve(strict=False)
+        if not _is_relative_to(abs_path, manifest_dir):
+            raise ValueError(f"Dependency path escapes manifest directory: {dep}")
+        if not abs_path.is_file():
+            raise FileNotFoundError(f"Dependency file not found: {abs_path}")
+        resolved.append(abs_path)
+        logger.debug("[runtime_fetcher] Fetched %s", abs_path)
+
+    return resolved

--- a/egg_cli.py
+++ b/egg_cli.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from egg.composer import compose
 from egg.hashing import verify_archive
 from egg.manifest import load_manifest
+from egg.runtime_fetcher import fetch_runtime_blocks
 
 __version__ = "0.1.0"
 
@@ -41,6 +42,9 @@ def build(args: argparse.Namespace) -> None:
 
     if output.exists() and not args.force:
         raise SystemExit(f"{output} exists. Use --force to overwrite.")
+
+    # Fetch any runtime dependencies referenced in the manifest
+    fetch_runtime_blocks(manifest)
 
     compose(manifest, output)
 

--- a/tests/test_runtime_fetcher.py
+++ b/tests/test_runtime_fetcher.py
@@ -1,0 +1,53 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+
+from egg.runtime_fetcher import fetch_runtime_blocks  # noqa: E402
+
+
+def test_fetch_local_dependencies(tmp_path: Path) -> None:
+    dep1 = tmp_path / "python.img"
+    dep2 = tmp_path / "r.img"
+    dep1.write_text("py")
+    dep2.write_text("r")
+    (tmp_path / "code.py").write_text("print('hi')\n")
+
+    manifest = tmp_path / "manifest.yaml"
+    manifest.write_text(
+        f"""
+name: Example
+description: desc
+cells:
+  - language: python
+    source: code.py
+dependencies:
+  - {dep1.name}
+  - {dep2.name}
+"""
+    )
+
+    paths = fetch_runtime_blocks(manifest)
+    assert paths == [dep1.resolve(), dep2.resolve()]
+
+
+def test_missing_dependency(tmp_path: Path) -> None:
+    (tmp_path / "code.py").write_text("print('hi')\n")
+    manifest = tmp_path / "manifest.yaml"
+    manifest.write_text(
+        """
+name: Example
+description: desc
+cells:
+  - language: python
+    source: code.py
+dependencies:
+  - missing.img
+"""
+    )
+
+    with pytest.raises(FileNotFoundError):
+        fetch_runtime_blocks(manifest)


### PR DESCRIPTION
## Summary
- implement `fetch_runtime_blocks` agent to gather runtime dependencies from manifests
- integrate runtime fetcher in the build command
- test runtime fetching and errors when dependencies are missing

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685089d740ec8328a5df0c3d97cb9d1f