### PR TITLE
Add PyYAML requirement note and test guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,11 +124,16 @@ roadmap.
 
 ### Testing
 
-Install dependencies using `pip install .` (or `pip install -e .`) so that
-packages like PyYAML are available. Then run `pytest` to execute the test
-suite. To check coverage, install `pytest-cov` and run
-`pytest --cov=egg --cov=egg_cli`. You can also check formatting or style with
-tools like `ruff` or `black`.
+PyYAML must be installed before running the test suite. The easiest way is to
+install the project itself which pulls in PyYAML as a dependency:
+
+```bash
+pip install .    # or `pip install -e .`
+```
+
+After installation run `pytest` to execute the tests. To check coverage, install
+`pytest-cov` and run `pytest --cov=egg --cov=egg_cli`. You can also check
+formatting or style with tools like `ruff` or `black`.
 
 ## Citation
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,6 @@
+try:
+    import yaml  # noqa: F401
+except ModuleNotFoundError as exc:
+    raise ModuleNotFoundError(
+        "PyYAML must be installed to run the test suite. Install with 'pip install PyYAML'."
+    ) from exc


### PR DESCRIPTION
## Summary
- clarify in README that PyYAML is required to run the tests
- add a guard in `tests/__init__.py` that throws a helpful error if PyYAML isn't installed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685089dbced88328a9cba920f868ac23