### PR TITLE
Add advanced manifest example and tests

### DIFF
--- a/examples/advanced.R
+++ b/examples/advanced.R
@@ -1,0 +1,1 @@
+print(paste("Advanced R", R.version$major))

--- a/examples/advanced.py
+++ b/examples/advanced.py
@@ -1,0 +1,5 @@
+"""Advanced Python example."""
+
+import sys
+
+print("Advanced Python", sys.version_info.major)

--- a/examples/advanced_manifest.yaml
+++ b/examples/advanced_manifest.yaml
@@ -1,0 +1,16 @@
+name: "Advanced Notebook"
+description: "Example demonstrating dependencies, permissions, and mixed languages"
+dependencies:
+  - python:3.11
+  - r:4.3
+  - bash:5
+permissions:
+  network: true
+  filesystem: read-write
+cells:
+  - language: python
+    source: advanced.py
+  - language: bash
+    source: say.sh
+  - language: r
+    source: advanced.R

--- a/examples/say.sh
+++ b/examples/say.sh
@@ -1,0 +1,1 @@
+echo "Advanced Bash"

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,33 @@
+import os
+import sys
+from pathlib import Path
+import logging
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+
+import egg_cli  # noqa: E402
+from egg.hashing import verify_archive  # noqa: E402
+
+EXAMPLE_ADV_MANIFEST = Path(__file__).resolve().parent.parent / "examples" / "advanced_manifest.yaml"
+
+
+def test_build_advanced_manifest(monkeypatch, tmp_path, caplog):
+    output = tmp_path / "advanced.egg"
+    caplog.set_level(logging.INFO)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "egg_cli.py",
+            "--verbose",
+            "build",
+            "--manifest",
+            str(EXAMPLE_ADV_MANIFEST),
+            "--output",
+            str(output),
+        ],
+    )
+    egg_cli.main()
+
+    assert output.is_file()
+    assert verify_archive(output)


### PR DESCRIPTION
## Summary
- provide an advanced manifest example with multiple languages, dependencies and permissions
- add associated example source files
- test building the advanced manifest archive

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685089d9e76483289c899f50ebb3be2e