### PR TITLE
Add sandboxer tests

### DIFF
--- a/egg/runtime_fetcher.py
+++ b/egg/runtime_fetcher.py
@@ -59,6 +59,9 @@ def fetch_runtime_blocks(manifest_path: Path | str) -> List[Path]:
     for dep in deps:
         if not isinstance(dep, str):
             raise ValueError("dependency entries must be strings")
+        if ":" in dep:
+            logger.debug("[runtime_fetcher] Skipping remote dependency %s", dep)
+            continue
         p = Path(dep)
         if p.is_absolute():
             raise ValueError(f"Absolute dependency paths are not allowed: {dep}")

--- a/egg/sandboxer.py
+++ b/egg/sandboxer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import tempfile
 from pathlib import Path
@@ -41,6 +42,8 @@ def prepare_images(
             continue
         img_dir = base / f"{lang}-image"
         img_dir.mkdir(parents=True, exist_ok=True)
+        config_path = img_dir / "microvm.json"
+        config_path.write_text(json.dumps({"language": lang}))
         logger.info("[sandboxer] prepared %s image at %s", lang, img_dir)
         images[lang] = img_dir
     return images

--- a/tests/test_sandboxer.py
+++ b/tests/test_sandboxer.py
@@ -1,0 +1,28 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+
+from egg.manifest import Manifest, Cell  # noqa: E402
+from egg.sandboxer import prepare_images  # noqa: E402
+
+
+def test_prepare_images_creates_dirs_and_config(tmp_path: Path) -> None:
+    manifest = Manifest(
+        name="Example",
+        description="desc",
+        cells=[
+            Cell(language="python", source="hello.py"),
+            Cell(language="r", source="hello.R"),
+        ],
+    )
+
+    images = prepare_images(manifest, tmp_path)
+
+    assert set(images.keys()) == {"python", "r"}
+    for lang, path in images.items():
+        assert path.is_dir()
+        config = path / "microvm.json"
+        assert config.is_file()
+        assert config.read_text()


### PR DESCRIPTION
## Summary
- test sandbox preparation
- create config file for each language image
- allow skipping remote dependencies

## Testing
- `flake8`
- `pylint egg egg_cli.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68508fad7d1c832884e7a1bef5678e9b