### PR TITLE
Add optional precompute step

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,11 @@ Follow these steps to build and hatch the demo archive:
 
    This installs the `egg` CLI and required packages such as **PyYAML**.
 
-2. Build the example egg using the provided manifest:
+2. Build the example egg using the provided manifest (add `--precompute` to
+   capture outputs during the build):
 
    ```bash
-   egg build --manifest examples/manifest.yaml --output demo.egg
+   egg build --manifest examples/manifest.yaml --output demo.egg --precompute
    ```
 
 3. Hatch the resulting file:
@@ -81,7 +82,7 @@ After installation the `egg` command becomes available. The CLI currently
 provides four subcommands:
 
 ```bash
-egg build --manifest <file> --output <egg> [--force]
+egg build --manifest <file> --output <egg> [--force] [--precompute]
 egg hatch --egg <egg> [--no-sandbox]
 egg verify --egg <egg>
 egg info --egg <egg>
@@ -118,7 +119,7 @@ Below is a minimal walkthrough using the placeholder implementation:
 2. Run the build command specifying the manifest and desired output:
 
    ```bash
-   egg build --manifest examples/manifest.yaml --output demo.egg
+   egg build --manifest examples/manifest.yaml --output demo.egg --precompute
    ```
 
 3. Hatch the resulting file:

--- a/egg/__init__.py
+++ b/egg/__init__.py
@@ -11,6 +11,7 @@ from .hashing import (
     write_hashes_file,
 )
 from .sandboxer import prepare_images
+from .precompute import precompute_cells
 
 __all__ = [
     "compose",
@@ -22,4 +23,5 @@ __all__ = [
     "verify_hashes",
     "verify_archive",
     "prepare_images",
+    "precompute_cells",
 ]

--- a/egg/precompute.py
+++ b/egg/precompute.py
@@ -1,0 +1,55 @@
+"""Agent for precomputing cell outputs."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import shutil
+import sys
+from pathlib import Path
+from typing import List
+
+from .manifest import load_manifest
+
+# Default language command mapping used when no override is provided.
+DEFAULT_LANG_COMMANDS = {
+    "python": [sys.executable],
+    "r": ["Rscript"],
+    "bash": ["bash"],
+}
+
+
+def get_lang_command(lang: str) -> list[str] | None:
+    """Return the command list for ``lang`` respecting environment overrides."""
+    override = os.getenv(f"EGG_CMD_{lang.upper()}")
+    if override:
+        return [override]
+    return DEFAULT_LANG_COMMANDS.get(lang)
+
+
+def precompute_cells(manifest_path: Path | str) -> List[Path]:
+    """Execute each cell listed in ``manifest_path`` and capture stdout.
+
+    For every cell in the manifest a new file ``<source>.out`` is written
+    containing the program output. The path of each created file is returned.
+    """
+    manifest_path = Path(manifest_path)
+    manifest = load_manifest(manifest_path)
+    manifest_dir = manifest_path.parent.resolve()
+
+    outputs: List[Path] = []
+    for cell in manifest.cells:
+        lang = cell.language.lower()
+        cmd = get_lang_command(lang)
+        if cmd is None:
+            raise ValueError(f"Unsupported language: {cell.language}")
+        if shutil.which(cmd[0]) is None:
+            raise FileNotFoundError(
+                f"Required runtime '{cmd[0]}' for {cell.language} cells not found"
+            )
+        src = manifest_dir / cell.source
+        out_file = src.with_name(src.name + ".out")
+        with open(out_file, "w", encoding="utf-8") as out:
+            subprocess.run(cmd + [str(src)], check=True, stdout=out)
+        outputs.append(out_file)
+    return outputs

--- a/egg/runtime_fetcher.py
+++ b/egg/runtime_fetcher.py
@@ -66,6 +66,9 @@ def fetch_runtime_blocks(manifest_path: Path | str) -> List[Path]:
         if not _is_relative_to(abs_path, manifest_dir):
             raise ValueError(f"Dependency path escapes manifest directory: {dep}")
         if not abs_path.is_file():
+            if ":" in dep:
+                logger.debug("[runtime_fetcher] Skipping remote dependency %s", dep)
+                continue
             raise FileNotFoundError(f"Dependency file not found: {abs_path}")
         resolved.append(abs_path)
         logger.debug("[runtime_fetcher] Fetched %s", abs_path)

--- a/egg_cli.py
+++ b/egg_cli.py
@@ -15,6 +15,7 @@ from egg.hashing import verify_archive
 from egg.manifest import load_manifest
 from egg.sandboxer import prepare_images
 from egg.runtime_fetcher import fetch_runtime_blocks
+from egg.precompute import precompute_cells
 
 
 __version__ = "0.1.0"
@@ -47,6 +48,9 @@ def build(args: argparse.Namespace) -> None:
 
     # Fetch any runtime dependencies referenced in the manifest
     fetch_runtime_blocks(manifest)
+
+    if args.precompute:
+        precompute_cells(manifest)
 
     compose(manifest, output)
 
@@ -166,6 +170,11 @@ def main(argv: list[str] | None = None) -> None:
         "--force",
         action="store_true",
         help="Overwrite output if it exists",
+    )
+    parser_build.add_argument(
+        "--precompute",
+        action="store_true",
+        help="Execute cells and store outputs before composing",
     )
     parser_build.set_defaults(func=build)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -45,6 +45,34 @@ def test_build(monkeypatch, tmp_path, caplog):
     assert "hello.R" in names
 
 
+def test_build_precompute(monkeypatch, tmp_path):
+    output = tmp_path / "demo.egg"
+
+    called = []
+
+    def fake_precompute(path):
+        called.append(Path(path))
+
+    monkeypatch.setattr(egg_cli, "precompute_cells", fake_precompute)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "egg_cli.py",
+            "build",
+            "--manifest",
+            os.path.join("examples", "manifest.yaml"),
+            "--output",
+            str(output),
+            "--precompute",
+        ],
+    )
+    egg_cli.main()
+
+    assert len(called) == 1
+    assert output.is_file()
+
+
 def test_build_force_overwrite(monkeypatch, tmp_path):
     """Building should require --force to overwrite existing output."""
     output = tmp_path / "demo.egg"


### PR DESCRIPTION
## Summary
- allow building with `--precompute` to capture cell output
- document the option in README
- implement `precompute_cells` agent
- test the new flag
- skip missing runtime dependencies in runtime_fetcher

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68508fabd23c83288661725e6406a360