### PR TITLE
Add Firecracker microvm support

### DIFF
--- a/egg/__init__.py
+++ b/egg/__init__.py
@@ -10,7 +10,7 @@ from .hashing import (
     verify_hashes,
     write_hashes_file,
 )
-from .sandboxer import prepare_images
+from .sandboxer import prepare_images, launch_microvm
 from .precompute import precompute_cells
 
 __all__ = [
@@ -23,5 +23,6 @@ __all__ = [
     "verify_hashes",
     "verify_archive",
     "prepare_images",
+    "launch_microvm",
     "precompute_cells",
 ]


### PR DESCRIPTION
## Summary
- implement minimal Firecracker micro-VM configuration
- write both `microvm.json` and compatibility `microvm.conf`
- add `launch_microvm` helper and export it

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685091c5fb588328b4d00938ef5c5d85