### PR TITLE
Fix extra tests lint errors

### DIFF
--- a/tests/test_precompute_extra.py
+++ b/tests/test_precompute_extra.py
@@ -7,7 +7,7 @@ import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
 
-from egg.precompute import get_lang_command, precompute_cells
+from egg.precompute import get_lang_command, precompute_cells  # noqa: E402
 
 
 def test_get_lang_command_env_override(monkeypatch):

--- a/tests/test_runtime_fetcher_extra.py
+++ b/tests/test_runtime_fetcher_extra.py
@@ -5,7 +5,7 @@ import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
 
-from egg.runtime_fetcher import fetch_runtime_blocks
+from egg.runtime_fetcher import fetch_runtime_blocks  # noqa: E402
 
 
 def base_manifest(tmpdir: Path, deps: str) -> Path:

--- a/tests/test_sandboxer_extra.py
+++ b/tests/test_sandboxer_extra.py
@@ -3,12 +3,12 @@ import sys
 from pathlib import Path
 import subprocess
 import tempfile
-import pytest
+import pytest  # noqa: F401
 
 sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
 
-from egg.sandboxer import build_microvm_image, launch_microvm, prepare_images
-from egg.manifest import Manifest, Cell
+from egg.sandboxer import build_microvm_image, launch_microvm, prepare_images  # noqa: E402
+from egg.manifest import Manifest, Cell  # noqa: E402
 
 
 def test_build_microvm_image(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- silence flake8 for import order warnings in extra tests
- mark unused pytest import in sandboxer extra test

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685095b977e88328a15251ee93da1ad2