### PR TITLE
Add automated badge updates to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,18 @@ jobs:
     - name: Pylint
       continue-on-error: true
       run: |
-        pylint egg egg_cli.py
+        pylint egg egg_cli.py | tee pylint.log
     - name: Run tests with coverage
       run: |
         pytest --cov=egg --cov=egg_cli --cov-report=xml \
                --cov-report=term-missing:skip-covered -q
+    - name: Update badges
+      if: github.event_name == 'push'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        python scripts/update_badges.py
+        git config user.name "GitHub Actions"
+        git config user.email "actions@github.com"
+        git commit -am "chore: update badges" || echo "No badge updates"
+        git push

--- a/scripts/update_badges.py
+++ b/scripts/update_badges.py
@@ -1,0 +1,49 @@
+import re
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+README_PATH = Path('README.md')
+COVERAGE_XML = Path('coverage.xml')
+PYLINT_LOG = Path('pylint.log')
+
+
+def update_coverage(readme_text: str) -> str:
+    if not COVERAGE_XML.exists():
+        return readme_text
+    root = ET.parse(COVERAGE_XML).getroot()
+    line_rate = float(root.get('line-rate', 0))
+    percent = round(line_rate * 100)
+    pattern = re.compile(r'(https://img.shields.io/badge/coverage-)(\d+)%25-(\w+)')
+
+    def repl(match: re.Match) -> str:
+        return f"{match.group(1)}{percent}%25-{match.group(3)}"
+
+    return pattern.sub(repl, readme_text)
+
+
+def update_pylint(readme_text: str) -> str:
+    if not PYLINT_LOG.exists():
+        return readme_text
+    rating = None
+    for line in PYLINT_LOG.read_text().splitlines():
+        if "Your code has been rated at" in line:
+            m = re.search(r"rated at ([0-9.]+)/10", line)
+            if m:
+                rating = float(m.group(1))
+    if rating is None:
+        return readme_text
+    rating_str = f"{rating:.2f}/10"
+    rating_url = rating_str.replace('/', '%2F')
+    pattern = re.compile(r'(https://img.shields.io/badge/pylint-)[0-9.]+%2F10-(\w+)')
+    return pattern.sub(lambda m: f"{m.group(1)}{rating_url}-{m.group(2)}", readme_text)
+
+
+def main() -> None:
+    text = README_PATH.read_text()
+    text = update_coverage(text)
+    text = update_pylint(text)
+    README_PATH.write_text(text)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- pipe pylint output to `pylint.log` in the workflow
- automatically update coverage and pylint badges after a successful push
- add `scripts/update_badges.py` for rewriting badges in `README.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850966f3dd4832883c0573f7f376799