### PR TITLE
Fix advanced manifest permission example

### DIFF
--- a/examples/advanced_manifest.yaml
+++ b/examples/advanced_manifest.yaml
@@ -7,7 +7,7 @@ dependencies:
   - bash:5
 permissions:
   network: true
-  filesystem: read-write
+  filesystem: true
 cells:
   - language: python
     source: advanced.py


### PR DESCRIPTION
## Summary
- make the advanced manifest use a boolean for filesystem permissions

## Testing
- `pytest tests/test_examples.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685098dc843483288f5c2d2df3f652ba