### PR TITLE
Centralize runtime command helper

### DIFF
--- a/egg/precompute.py
+++ b/egg/precompute.py
@@ -10,21 +10,7 @@ from pathlib import Path
 from typing import List
 
 from .manifest import load_manifest
-
-# Default language command mapping used when no override is provided.
-DEFAULT_LANG_COMMANDS = {
-    "python": [sys.executable],
-    "r": ["Rscript"],
-    "bash": ["bash"],
-}
-
-
-def get_lang_command(lang: str) -> list[str] | None:
-    """Return the command list for ``lang`` respecting environment overrides."""
-    override = os.getenv(f"EGG_CMD_{lang.upper()}")
-    if override:
-        return [override]
-    return DEFAULT_LANG_COMMANDS.get(lang)
+from .utils import get_lang_command
 
 
 def precompute_cells(manifest_path: Path | str) -> List[Path]:

--- a/egg/utils.py
+++ b/egg/utils.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 """Utility helpers used across the egg codebase."""
 
 from pathlib import Path
+import os
+import sys
+
+__all__ = ["_is_relative_to", "get_lang_command", "DEFAULT_LANG_COMMANDS"]
 
 
 def _is_relative_to(path: Path, base: Path) -> bool:
@@ -15,3 +19,19 @@ def _is_relative_to(path: Path, base: Path) -> bool:
         return True
     except ValueError:
         return False
+
+
+DEFAULT_LANG_COMMANDS = {
+    "python": [sys.executable],
+    "r": ["Rscript"],
+    "bash": ["bash"],
+}
+
+
+def get_lang_command(lang: str) -> list[str] | None:
+    """Return the command list for ``lang`` respecting environment overrides."""
+
+    override = os.getenv(f"EGG_CMD_{lang.upper()}")
+    if override:
+        return [override]
+    return DEFAULT_LANG_COMMANDS.get(lang)

--- a/egg_cli.py
+++ b/egg_cli.py
@@ -16,26 +16,14 @@ from egg.manifest import load_manifest
 from egg.sandboxer import prepare_images
 from egg.runtime_fetcher import fetch_runtime_blocks
 from egg.precompute import precompute_cells
+from egg.utils import get_lang_command
 
 
 __version__ = "0.1.0"
 
 logger = logging.getLogger(__name__)
 
-# Mapping of supported languages to their command prefixes.
-DEFAULT_LANG_COMMANDS = {
-    "python": [sys.executable],
-    "r": ["Rscript"],
-    "bash": ["bash"],
-}
 
-
-def get_lang_command(lang: str) -> list[str] | None:
-    """Return the command list for ``lang``, honoring environment overrides."""
-    override = os.getenv(f"EGG_CMD_{lang.upper()}")
-    if override:
-        return [override]
-    return DEFAULT_LANG_COMMANDS.get(lang)
 
 
 def build(args: argparse.Namespace) -> None:

--- a/tests/test_precompute_extra.py
+++ b/tests/test_precompute_extra.py
@@ -7,7 +7,8 @@ import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
 
-from egg.precompute import get_lang_command, precompute_cells  # noqa: E402
+from egg.utils import get_lang_command  # noqa: E402
+from egg.precompute import precompute_cells  # noqa: E402
 
 
 def test_get_lang_command_env_override(monkeypatch):


### PR DESCRIPTION
## Summary
- create `egg.utils.get_lang_command`
- replace duplicated code in `egg_cli` and `egg.precompute`
- update tests for new import

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685098de09dc8328bbf645b4cb0f96d7