### PR TITLE
Support dependencies field in manifest

### DIFF
--- a/egg/manifest.py
+++ b/egg/manifest.py
@@ -32,6 +32,7 @@ class Manifest:
     description: str
     cells: List[Cell]
     permissions: dict[str, bool] | None = None
+    dependencies: List[str] | None = None
 
 
 def _normalize_source(path: str | Path, manifest_dir: Path) -> str:
@@ -65,7 +66,7 @@ def load_manifest(path: Path | str) -> Manifest:
         raise ValueError("Manifest root must be a mapping")
 
     required_fields = {"name", "description", "cells"}
-    optional_fields = {"permissions"}
+    optional_fields = {"permissions", "dependencies"}
     for field in required_fields:
         if field not in data:
             raise ValueError(f"Missing required field: {field}")
@@ -98,6 +99,19 @@ def load_manifest(path: Path | str) -> Manifest:
                 raise ValueError(f"Permission '{perm}' must be a boolean")
             permissions[str(perm)] = val
 
+    deps_data = data.get("dependencies")
+    dependencies: List[str] | None
+    if deps_data is None:
+        dependencies = None
+    else:
+        if not isinstance(deps_data, list):
+            raise ValueError("'dependencies' must be a list")
+        dependencies = []
+        for i, dep in enumerate(deps_data):
+            if not isinstance(dep, str):
+                raise ValueError("dependency entries must be strings")
+            dependencies.append(dep)
+
     manifest_dir = Path(path).resolve().parent
     cells: List[Cell] = []
     for i, cell in enumerate(cells_data):
@@ -117,4 +131,5 @@ def load_manifest(path: Path | str) -> Manifest:
         description=data["description"],
         cells=cells,
         permissions=permissions,
+        dependencies=dependencies,
     )

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -10,6 +10,7 @@ sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
 from egg.manifest import Cell, Manifest, load_manifest  # noqa: E402
 
 EXAMPLE_MANIFEST = Path(__file__).resolve().parent.parent / "examples" / "manifest.yaml"
+EXAMPLE_ADV_MANIFEST = Path(__file__).resolve().parent.parent / "examples" / "advanced_manifest.yaml"
 
 
 def test_load_manifest_example():
@@ -246,3 +247,21 @@ cells:
     )
     with pytest.raises(ValueError, match="Permission 'network' must be a boolean"):
         load_manifest(path)
+
+
+def test_manifest_with_dependencies(tmp_path: Path) -> None:
+    path = tmp_path / "manifest.yaml"
+    path.write_text(
+        """
+name: Example
+description: desc
+dependencies:
+  - python:3.11
+  - r:4.3
+cells:
+  - language: python
+    source: hello.py
+"""
+    )
+    manifest = load_manifest(path)
+    assert manifest.dependencies == ["python:3.11", "r:4.3"]


### PR DESCRIPTION
## Summary
- allow `dependencies` in manifest files
- validate that dependencies are a list of strings
- store dependencies in `Manifest`
- test parsing manifests with dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685098dbb20483289a19858fe3657bf5