### PR TITLE
Handle runtime block files in composer

### DIFF
--- a/FORMAT.md
+++ b/FORMAT.md
@@ -71,6 +71,13 @@ the `.egg` file and referenced by the manifest. Runtime blocks and other
 assets appear in later layers but remain associated with their cells via
 these manifest entries.
 
+### Runtime Blocks Directory
+
+Local dependency files resolved by the runtime block fetcher are included
+in the archive under the `runtime/` directory using their original file
+names. Container-style entries like `python:3.11` are recorded in the
+manifest but are not bundled into the egg.
+
 ### Breadth-First Loading
 
 - UI loads Layer 1 & 2 instantly (title, author, structure, text, previews).

--- a/egg/composer.py
+++ b/egg/composer.py
@@ -58,8 +58,13 @@ def _collect_sources(manifest: dict, manifest_dir: Path) -> Iterable[Path]:
             yield _normalize_source(source, manifest_dir)
 
 
-def compose(manifest_path: Path | str, output_path: Path | str) -> None:
-    """Compose an egg archive by zipping manifest and sources.
+def compose(
+    manifest_path: Path | str,
+    output_path: Path | str,
+    *,
+    dependencies: Iterable[Path] | None = None,
+) -> None:
+    """Compose an egg archive by zipping manifest, sources, and dependencies.
 
     Parameters
     ----------
@@ -67,6 +72,8 @@ def compose(manifest_path: Path | str, output_path: Path | str) -> None:
         Path to the manifest YAML file describing sources.
     output_path : Path | str
         Destination ``.egg`` archive path.
+    dependencies : Iterable[Path] | None, optional
+        Additional files to include under ``runtime/``.
     """
     manifest_path = Path(manifest_path)
     output_path = Path(output_path)
@@ -94,6 +101,16 @@ def compose(manifest_path: Path | str, output_path: Path | str) -> None:
             dest.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(src, dest)
             copied.append(dest)
+
+        # copy runtime dependencies under runtime/
+        runtime_dir = tmpdir_path / "runtime"
+        if dependencies:
+            for dep in dependencies:
+                if isinstance(dep, Path):
+                    dest = runtime_dir / dep.name
+                    dest.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(dep, dest)
+                    copied.append(dest)
 
         # write hashes file and signature
         hashes = compute_hashes(copied, base_dir=tmpdir_path)

--- a/egg_cli.py
+++ b/egg_cli.py
@@ -47,12 +47,12 @@ def build(args: argparse.Namespace) -> None:
         raise SystemExit(f"{output} exists. Use --force to overwrite.")
 
     # Fetch any runtime dependencies referenced in the manifest
-    fetch_runtime_blocks(manifest)
+    deps = fetch_runtime_blocks(manifest)
 
     if args.precompute:
         precompute_cells(manifest)
 
-    compose(manifest, output)
+    compose(manifest, output, dependencies=deps)
 
     if not verify_archive(output):
         raise SystemExit("Hash verification failed")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -505,6 +505,37 @@ def test_hashes_in_archive(monkeypatch, tmp_path):
             assert hashlib.sha256(data).hexdigest() == digest
 
 
+def test_build_includes_dependency_files(monkeypatch, tmp_path):
+    dep = tmp_path / "python.img"
+    dep.write_text("py")
+    src = tmp_path / "hello.py"
+    src.write_text("print('hi')\n")
+    manifest = tmp_path / "manifest.yaml"
+    manifest.write_text(
+        """
+name: Example
+description: desc
+dependencies:
+  - python.img
+cells:
+  - language: python
+    source: hello.py
+"""
+    )
+    output = tmp_path / "demo.egg"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["egg_cli.py", "build", "--manifest", str(manifest), "--output", str(output)],
+    )
+    egg_cli.main()
+
+    assert verify_archive(output)
+    with zipfile.ZipFile(output) as zf:
+        names = set(zf.namelist())
+    assert "runtime/python.img" in names
+
+
 def test_deterministic_build(monkeypatch, tmp_path):
     base_args = [
         "egg_cli.py",
@@ -636,8 +667,8 @@ def test_build_detects_tampering(monkeypatch, tmp_path):
 
     original = egg_cli.compose
 
-    def tamper(manifest, out):
-        original(manifest, out)
+    def tamper(manifest, out, *, dependencies=None):
+        original(manifest, out, dependencies=dependencies)
         with zipfile.ZipFile(out, "r") as zf:
             contents = {name: zf.read(name) for name in zf.namelist()}
         contents["hello.py"] = b"print('tampered')\n"

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -63,7 +63,9 @@ def test_verify_archive_with_extra_file(tmp_path: Path) -> None:
     """Archives containing files not listed in hashes.yaml should fail."""
     output = tmp_path / "demo.egg"
     compose(
-        Path(__file__).resolve().parent.parent / "examples" / "manifest.yaml", output
+        Path(__file__).resolve().parent.parent / "examples" / "manifest.yaml",
+        output,
+        dependencies=[],
     )
 
     # Append an extra file not recorded in hashes.yaml
@@ -87,7 +89,9 @@ def test_sign_hashes_and_verify_signature(tmp_path: Path) -> None:
 def test_verify_archive_bad_signature(tmp_path: Path) -> None:
     output = tmp_path / "demo.egg"
     compose(
-        Path(__file__).resolve().parent.parent / "examples" / "manifest.yaml", output
+        Path(__file__).resolve().parent.parent / "examples" / "manifest.yaml",
+        output,
+        dependencies=[],
     )
 
     # Tamper signature


### PR DESCRIPTION
## Summary
- include runtime dependencies when composing eggs
- pass dependency list from CLI build command
- document runtime block directory
- test inclusion of dependency files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685098dee10c83289975d82e7cc312cd