### PR TITLE
Ensure manifest path standardized

### DIFF
--- a/egg/composer.py
+++ b/egg/composer.py
@@ -77,8 +77,8 @@ def compose(manifest_path: Path | str, output_path: Path | str) -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         tmpdir_path = Path(tmpdir)
         copied: List[Path] = []
-        # copy manifest
-        manifest_copy = tmpdir_path / manifest_path.name
+        # copy manifest under a fixed name inside the archive
+        manifest_copy = tmpdir_path / "manifest.yaml"
         shutil.copy2(manifest_path, manifest_copy)
         copied.append(manifest_copy)
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -2,6 +2,9 @@ import os
 import sys
 from pathlib import Path
 import logging
+import zipfile
+import subprocess
+import shutil
 
 sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
 
@@ -20,8 +23,6 @@ EXAMPLE_JULIA_MANIFEST = (
 def test_build_advanced_manifest(monkeypatch, tmp_path, caplog):
     output = tmp_path / "advanced.egg"
     caplog.set_level(logging.INFO)
-    for dep in ["python:3.11", "r:4.3", "bash:5"]:
-        (EXAMPLE_ADV_MANIFEST.parent / dep).write_text("img")
     monkeypatch.setattr(
         sys,
         "argv",
@@ -40,6 +41,10 @@ def test_build_advanced_manifest(monkeypatch, tmp_path, caplog):
 
     assert output.is_file()
     assert verify_archive(output)
+    with zipfile.ZipFile(output) as zf:
+        names = zf.namelist()
+    assert "manifest.yaml" in names
+    assert "advanced_manifest.yaml" not in names
 
 
 def test_build_julia_manifest(monkeypatch, tmp_path, caplog):
@@ -62,3 +67,58 @@ def test_build_julia_manifest(monkeypatch, tmp_path, caplog):
 
     assert output.is_file()
     assert verify_archive(output)
+
+
+def test_hatch_custom_manifest_name(monkeypatch, tmp_path, caplog):
+    script = tmp_path / "hello.py"
+    script.write_text("print('hi')\n")
+
+    manifest = tmp_path / "custom.yaml"
+    manifest.write_text(
+        """
+name: Demo
+description: desc
+cells:
+  - language: python
+    source: hello.py
+"""
+    )
+    egg_path = tmp_path / "demo.egg"
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "egg_cli.py",
+            "build",
+            "--manifest",
+            str(manifest),
+            "--output",
+            str(egg_path),
+        ],
+    )
+    egg_cli.main()
+
+    with zipfile.ZipFile(egg_path) as zf:
+        assert "manifest.yaml" in zf.namelist()
+        assert "custom.yaml" not in zf.namelist()
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, check=True):
+        calls.append(cmd)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(shutil, "which", lambda cmd: cmd)
+    caplog.set_level(logging.INFO)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["egg_cli.py", "--verbose", "hatch", "--egg", str(egg_path)],
+    )
+    egg_cli.main()
+
+    assert any(
+        cmd[0] == sys.executable and cmd[1].endswith("hello.py") for cmd in calls
+    )
+    assert f"[hatch] Completed running {egg_path}" in caplog.text


### PR DESCRIPTION
## Summary
- copy manifest into egg archives using a fixed `manifest.yaml` name
- assert manifest name normalization when building examples
- test building and hatching from a custom manifest filename

## Testing
- `flake8`
- `pylint egg egg_cli.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685098dad56c8328afbe8f6eabb2af08