### PR TITLE
Simplify runtime fetcher check

### DIFF
--- a/egg/runtime_fetcher.py
+++ b/egg/runtime_fetcher.py
@@ -71,11 +71,6 @@ def fetch_runtime_blocks(manifest_path: Path | str) -> List[Path | str]:
         if not _is_relative_to(abs_path, manifest_dir):
             raise ValueError(f"Dependency path escapes manifest directory: {dep}")
         if not abs_path.is_file():
-            if ":" in dep:  # pragma: no cover
-                logger.debug(
-                    "[runtime_fetcher] Skipping remote dependency %s", dep
-                )  # pragma: no cover
-                continue
             raise FileNotFoundError(f"Dependency file not found: {abs_path}")
         resolved.append(abs_path)
         logger.debug("[runtime_fetcher] Fetched %s", abs_path)


### PR DESCRIPTION
## Summary
- drop redundant colon check when dependency file is missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68509c148ec88328aef2deb71b28aa78