### PR TITLE
Add manifest type check in runtime fetcher

### DIFF
--- a/egg/runtime_fetcher.py
+++ b/egg/runtime_fetcher.py
@@ -46,7 +46,11 @@ def fetch_runtime_blocks(manifest_path: Path | str) -> List[Path | str]:
 
     manifest_path = Path(manifest_path)
     with open(manifest_path, "r", encoding="utf-8") as f:
-        manifest = yaml.safe_load(f) or {}
+        manifest = yaml.safe_load(f)
+    if manifest is None:
+        manifest = {}
+    if not isinstance(manifest, dict):
+        raise ValueError("Manifest root must be a mapping")
 
     deps = manifest.get("dependencies", [])
     if deps is None:

--- a/tests/test_runtime_fetcher_extra.py
+++ b/tests/test_runtime_fetcher_extra.py
@@ -49,3 +49,10 @@ def test_fetch_escaped_path(tmp_path: Path) -> None:
     manifest = base_manifest(tmp_path, "\n  - ../escape.img")
     with pytest.raises(ValueError):
         fetch_runtime_blocks(manifest)
+
+
+def test_manifest_root_not_mapping(tmp_path: Path) -> None:
+    manifest = tmp_path / "manifest.yaml"
+    manifest.write_text("- just a list\n")
+    with pytest.raises(ValueError, match="Manifest root must be a mapping"):
+        fetch_runtime_blocks(manifest)


### PR DESCRIPTION
## Summary
- validate that runtime manifest is a mapping
- test runtime fetcher on invalid manifest root

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68509c14054c83288db0a424d9c5253e