### PR TITLE
Handle duplicate runtime deps

### DIFF
--- a/egg/composer.py
+++ b/egg/composer.py
@@ -96,10 +96,15 @@ def compose(
 
         # copy runtime dependencies under runtime/
         runtime_dir = tmpdir_path / "runtime"
+        seen_runtime: set[str] = set()
         if dependencies:
             for dep in dependencies:
                 if isinstance(dep, Path):
-                    dest = runtime_dir / dep.name
+                    dest_name = dep.name
+                    if dest_name in seen_runtime:
+                        raise ValueError(f"Duplicate dependency filename: {dest_name}")
+                    seen_runtime.add(dest_name)
+                    dest = runtime_dir / dest_name
                     dest.parent.mkdir(parents=True, exist_ok=True)
                     shutil.copy2(dep, dest)
                     copied.append(dest)

--- a/tests/test_composer.py
+++ b/tests/test_composer.py
@@ -1,8 +1,38 @@
 import pytest
 from pathlib import Path
-from egg.composer import _normalize_source
+from egg.composer import _normalize_source, compose
 
 
 def test_normalize_source_absolute(tmp_path: Path) -> None:
     with pytest.raises(ValueError):
         _normalize_source("/abs.py", tmp_path)
+
+
+def test_duplicate_runtime_dependency(tmp_path: Path) -> None:
+    dep1 = tmp_path / "a" / "python.img"
+    dep2 = tmp_path / "b" / "python.img"
+    dep1.parent.mkdir()
+    dep2.parent.mkdir()
+    dep1.write_text("py")
+    dep2.write_text("py")
+
+    src = tmp_path / "code.py"
+    src.write_text("print('hi')\n")
+
+    manifest = tmp_path / "manifest.yaml"
+    manifest.write_text(
+        """
+name: Example
+description: desc
+cells:
+  - language: python
+    source: code.py
+dependencies:
+  - a/python.img
+  - b/python.img
+"""
+    )
+
+    output = tmp_path / "demo.egg"
+    with pytest.raises(ValueError):
+        compose(manifest, output, dependencies=[dep1, dep2])


### PR DESCRIPTION
## Summary
- detect duplicate names for runtime dependencies
- test duplicate runtime dependency handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68509c153bc88328aef16128fa4952f8