### PR TITLE
Add pre-commit hooks and update workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest pytest-cov flake8 black pylint
+        pip install pytest pytest-cov flake8 black pylint pre-commit
         pip install -e .
+    - name: Run pre-commit
+      run: pre-commit run --all-files
     - name: Commit formatted code
       if: github.event_name == 'push'
       env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.3.0
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8
+  - repo: https://github.com/pycqa/pylint
+    rev: v3.2.2
+    hooks:
+      - id: pylint
+        additional_dependencies: []
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest -q
+        language: system
+        types: [python]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,12 @@ Thank you for considering contributing to **egg file format**!
 
 4. **Code Style:**
    - Follow existing conventions and document public APIs.
+   - Install and enable pre-commit hooks:
+
+     ```bash
+     pip install pre-commit
+     pre-commit install
+     ```
 
 5. **Security:**
    - Do not submit code that weakens sandboxing, verification, or reproducibility.


### PR DESCRIPTION
## Summary
- add pre-commit config for black, flake8, pylint and pytest
- document how to enable pre-commit hooks
- run pre-commit in CI

## Testing
- `pre-commit run --files CONTRIBUTING.md .github/workflows/ci.yml .pre-commit-config.yaml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68509e96c76c8328a00e6382955179b8