### PR TITLE
Enhance manifest metadata support

### DIFF
--- a/egg/manifest.py
+++ b/egg/manifest.py
@@ -33,6 +33,9 @@ class Manifest:
     cells: List[Cell]
     permissions: dict[str, bool] | None = None
     dependencies: List[str] | None = None
+    author: str | None = None
+    created: str | None = None
+    license: str | None = None
 
 
 def _normalize_source(path: str | Path, manifest_dir: Path) -> str:
@@ -66,7 +69,7 @@ def load_manifest(path: Path | str) -> Manifest:
         raise ValueError("Manifest root must be a mapping")
 
     required_fields = {"name", "description", "cells"}
-    optional_fields = {"permissions", "dependencies"}
+    optional_fields = {"permissions", "dependencies", "author", "created", "license"}
     for field in required_fields:
         if field not in data:
             raise ValueError(f"Missing required field: {field}")
@@ -112,6 +115,18 @@ def load_manifest(path: Path | str) -> Manifest:
                 raise ValueError("dependency entries must be strings")
             dependencies.append(dep)
 
+    author_data = data.get("author")
+    if author_data is not None and not isinstance(author_data, str):
+        raise ValueError("'author' must be a string")
+
+    created_data = data.get("created")
+    if created_data is not None and not isinstance(created_data, str):
+        raise ValueError("'created' must be a string")
+
+    license_data = data.get("license")
+    if license_data is not None and not isinstance(license_data, str):
+        raise ValueError("'license' must be a string")
+
     manifest_dir = Path(path).resolve().parent
     cells: List[Cell] = []
     for i, cell in enumerate(cells_data):
@@ -132,4 +147,7 @@ def load_manifest(path: Path | str) -> Manifest:
         cells=cells,
         permissions=permissions,
         dependencies=dependencies,
+        author=author_data,
+        created=created_data,
+        license=license_data,
     )

--- a/egg_cli.py
+++ b/egg_cli.py
@@ -106,6 +106,12 @@ def info(args: argparse.Namespace) -> None:
 
     print(f"Name: {manifest.name}")
     print(f"Description: {manifest.description}")
+    if manifest.author is not None:
+        print(f"Author: {manifest.author}")
+    if manifest.license is not None:
+        print(f"License: {manifest.license}")
+    if manifest.created is not None:
+        print(f"Created: {manifest.created}")
     print("Cells:")
     for cell in manifest.cells:
         print(f"  - {cell.language}: {cell.source}")

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -267,3 +267,66 @@ cells:
     )
     manifest = load_manifest(path)
     assert manifest.dependencies == ["python:3.11", "r:4.3"]
+
+
+def test_manifest_optional_fields(tmp_path: Path) -> None:
+    path = tmp_path / "manifest.yaml"
+    path.write_text(
+        """
+name: Example
+description: desc
+author: Alice
+created: "2025-06-16T12:00:00Z"
+license: MIT
+cells:
+  - language: python
+    source: hello.py
+"""
+    )
+    (tmp_path / "hello.py").write_text("print('hi')\n")
+    manifest = load_manifest(path)
+    assert manifest.author == "Alice"
+    assert manifest.created == "2025-06-16T12:00:00Z"
+    assert manifest.license == "MIT"
+
+
+def test_author_must_be_string(tmp_path: Path) -> None:
+    path = tmp_path / "manifest.yaml"
+    path.write_text(
+        """
+name: Example
+description: desc
+author: [bob]
+cells: []
+"""
+    )
+    with pytest.raises(ValueError, match="'author' must be a string"):
+        load_manifest(path)
+
+
+def test_created_must_be_string(tmp_path: Path) -> None:
+    path = tmp_path / "manifest.yaml"
+    path.write_text(
+        """
+name: Example
+description: desc
+created: {year: 2025}
+cells: []
+"""
+    )
+    with pytest.raises(ValueError, match="'created' must be a string"):
+        load_manifest(path)
+
+
+def test_license_must_be_string(tmp_path: Path) -> None:
+    path = tmp_path / "manifest.yaml"
+    path.write_text(
+        """
+name: Example
+description: desc
+license: [MIT]
+cells: []
+"""
+    )
+    with pytest.raises(ValueError, match="'license' must be a string"):
+        load_manifest(path)


### PR DESCRIPTION
## Summary
- add `author`, `created`, and `license` optional fields to manifests
- display new fields with the `info` command
- validate new fields when loading manifests
- test optional fields and type validation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68509fc7a1c08328b4822ca300ebd73c