### PR TITLE
Remove pylint from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,11 +7,6 @@ repos:
     rev: 7.0.0
     hooks:
       - id: flake8
-  - repo: https://github.com/pycqa/pylint
-    rev: v3.2.2
-    hooks:
-      - id: pylint
-        additional_dependencies: []
   - repo: local
     hooks:
       - id: pytest


### PR DESCRIPTION
## Summary
- disable pylint hook in pre-commit configuration

## Testing
- `pre-commit run --files .pre-commit-config.yaml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850a1435c048328ad0cf1be099e0846