### PR TITLE
Move linting and badges to pre-commit

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,4 +4,4 @@ Please review the checklist before submitting:
 
 - [ ] Tests added or updated
 - [ ] Documentation updated if needed
-- [ ] `flake8`, `black --check`, and `pytest -q` pass
+- [ ] `pre-commit run --all-files` passes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,35 +25,12 @@ jobs:
         pip install -e .
     - name: Run pre-commit
       run: pre-commit run --all-files
-    - name: Commit formatted code
+    - name: Commit results
       if: github.event_name == 'push'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        black .
         git config user.name "GitHub Actions"
         git config user.email "actions@github.com"
-        git commit -am "chore: format with black" || echo "No changes to commit"
-        git push
-    - name: Lint
-      run: |
-        flake8
-        black --check .
-    - name: Pylint
-      continue-on-error: true
-      run: |
-        pylint egg egg_cli.py | tee pylint.log
-    - name: Run tests with coverage
-      run: |
-        pytest --cov=egg --cov=egg_cli --cov-report=xml \
-               --cov-report=term-missing:skip-covered -q
-    - name: Update badges
-      if: github.event_name == 'push'
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        python scripts/update_badges.py
-        git config user.name "GitHub Actions"
-        git config user.email "actions@github.com"
-        git commit -am "chore: update badges" || echo "No badge updates"
+        git commit -am "chore: apply pre-commit fixes" || echo "No changes to commit"
         git push

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ dist/
 # OS-specific files
 .DS_Store
 Thumbs.db
+pylint.log
+coverage.xml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,8 +9,21 @@ repos:
       - id: flake8
   - repo: local
     hooks:
+      - id: pylint
+        name: pylint
+        entry: bash -c 'pylint egg egg_cli.py | tee pylint.log || true'
+        language: system
+        pass_filenames: false
       - id: pytest
         name: pytest
-        entry: pytest -q
+        entry: >-
+          pytest --cov=egg --cov=egg_cli --cov-report=xml \
+                 --cov-report=term-missing:skip-covered -q
         language: system
         types: [python]
+      - id: update-badges
+        name: update-badges
+        entry: python scripts/update_badges.py
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/README.md
+++ b/README.md
@@ -52,9 +52,10 @@ Use `egg <command> -h` to see all options. Runtime commands can be overridden wi
 
 ```bash
 pip install .       # installs PyYAML and the CLI
-pytest
+pre-commit run --all-files
 ```
-Optional coverage can be gathered with `pytest --cov=egg --cov=egg_cli`.
+This formats code, lints with flake8 and pylint, runs tests with coverage,
+and updates the README badges.
 
 ---
 


### PR DESCRIPTION
## Summary
- run pylint, pytest w/coverage and badge updater as local hooks
- simplify CI to just run pre-commit
- ignore generated reports
- update testing docs and PR template

## Testing
- `pre-commit run --files .github/pull_request_template.md .github/workflows/ci.yml .pre-commit-config.yaml README.md`

------
https://chatgpt.com/codex/tasks/task_e_6850a301930883289d674097f1e4ba71