### PR TITLE
Ensure valid hash mapping in load_hashes

### DIFF
--- a/egg/hashing.py
+++ b/egg/hashing.py
@@ -80,7 +80,13 @@ def write_hashes_file(hashes: Dict[str, str], path: Path) -> None:
 def load_hashes(path: Path) -> Dict[str, str]:
     """Load a YAML file of hashes."""
     with open(path, "r", encoding="utf-8") as f:
-        return yaml.safe_load(f) or {}
+        data = yaml.safe_load(f)
+
+    if data is None:
+        return {}
+    if not isinstance(data, dict):
+        raise ValueError("hashes.yaml must contain a mapping")
+    return data
 
 
 def sign_hashes(path: Path, *, key: bytes | None = None) -> str:

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -59,6 +59,14 @@ def test_duplicate_basenames(tmp_path: Path) -> None:
         compute_hashes([f1, f2])
 
 
+def test_load_hashes_requires_mapping(tmp_path: Path) -> None:
+    """Non-mapping YAML content should raise ValueError."""
+    path = tmp_path / "hashes.yaml"
+    path.write_text("- a\n- b\n")
+    with pytest.raises(ValueError):
+        load_hashes(path)
+
+
 def test_verify_archive_with_extra_file(tmp_path: Path) -> None:
     """Archives containing files not listed in hashes.yaml should fail."""
     output = tmp_path / "demo.egg"


### PR DESCRIPTION
## Summary
- validate that `hashes.yaml` contains a mapping when loading
- test that a non-mapping YAML file causes an error

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850a543d744832886b9a7cdfe1b5e20