### PR TITLE
Remove unused os import

### DIFF
--- a/egg/precompute.py
+++ b/egg/precompute.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import subprocess
 import shutil
 import sys


### PR DESCRIPTION
## Summary
- clean up `precompute.py` by removing unused `os` import

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850a546995883289850bbc701e6da44