### PR TITLE
Fix global options display in egg subcommand help

### DIFF
--- a/egg_cli.py
+++ b/egg_cli.py
@@ -143,7 +143,9 @@ def main(argv: list[str] | None = None) -> None:
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
 
-    parser_build = subparsers.add_parser("build", help="Build an egg file")
+    parser_build = subparsers.add_parser(
+        "build", help="Build an egg file", parents=[global_parser]
+    )
 
     parser_build.add_argument(
         "-m",
@@ -170,7 +172,9 @@ def main(argv: list[str] | None = None) -> None:
     )
     parser_build.set_defaults(func=build)
 
-    parser_hatch = subparsers.add_parser("hatch", help="Hatch an egg file")
+    parser_hatch = subparsers.add_parser(
+        "hatch", help="Hatch an egg file", parents=[global_parser]
+    )
     parser_hatch.add_argument(
         "-e", "--egg", default="out.egg", help="Egg file to hatch"
     )
@@ -179,7 +183,9 @@ def main(argv: list[str] | None = None) -> None:
     )
     parser_hatch.set_defaults(func=hatch)
 
-    parser_verify = subparsers.add_parser("verify", help="Verify an egg archive")
+    parser_verify = subparsers.add_parser(
+        "verify", help="Verify an egg archive", parents=[global_parser]
+    )
     parser_verify.add_argument(
         "-e",
         "--egg",
@@ -188,7 +194,9 @@ def main(argv: list[str] | None = None) -> None:
     )
     parser_verify.set_defaults(func=verify)
 
-    parser_info = subparsers.add_parser("info", help="Show manifest summary")
+    parser_info = subparsers.add_parser(
+        "info", help="Show manifest summary", parents=[global_parser]
+    )
     parser_info.add_argument(
         "-e",
         "--egg",
@@ -197,11 +205,10 @@ def main(argv: list[str] | None = None) -> None:
     )
     parser_info.set_defaults(func=info)
 
-    args, remaining = parser.parse_known_args(argv)
-    if remaining:
-        extras = global_parser.parse_args(remaining)
-        for key, value in vars(extras).items():
-            setattr(args, key, value)
+    args, _ = parser.parse_known_args(argv)
+    extras, _ = global_parser.parse_known_args(argv)
+    for key, value in vars(extras).items():
+        setattr(args, key, value)
     if args.verbose >= 2:
         level = logging.DEBUG
     elif args.verbose == 1:


### PR DESCRIPTION
## Summary
- show global options in subparser help
- ensure verbose/other globals parse correctly with any argument order

## Testing
- `pytest -q`
- `python egg_cli.py build -h`

------
https://chatgpt.com/codex/tasks/task_e_6850a53fac408328b3387a7ebdabd474