### PR TITLE
Use SPDX license

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,7 @@ readme = "README.md"
 description = "CLI tools for the egg file format"
 requires-python = ">=3.8"
 dependencies = ["PyYAML>=6"]
-license = { text = "MIT" }
-classifiers = ["License :: OSI Approved :: MIT License"]
+license = "MIT"
 
 [project.scripts]
 egg = "egg_cli:main"


### PR DESCRIPTION
## Summary
- use SPDX string for license instead of deprecated table

## Testing
- `pre-commit run --files pyproject.toml`
- `pytest -q`
- `python -m build --wheel`


------
https://chatgpt.com/codex/tasks/task_e_6850a584d52083289281089f390c7a10