### PR TITLE
Improve CLI info output and pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,11 +16,15 @@ repos:
         pass_filenames: false
       - id: pytest
         name: pytest
-        entry: >-
-          pytest --cov=egg --cov=egg_cli --cov-report=xml \
-                 --cov-report=term-missing:skip-covered -q
+        entry: pytest
         language: system
-        types: [python]
+        pass_filenames: false
+        args:
+          - --cov=egg
+          - --cov=egg_cli
+          - --cov-report=xml
+          - --cov-report=term-missing:skip-covered
+          - -q
       - id: update-badges
         name: update-badges
         entry: python scripts/update_badges.py

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # 🥚 egg file format
 
 [![Coverage](https://img.shields.io/badge/coverage-98%25-brightgreen)](https://img.shields.io)
-[![Pylint](https://img.shields.io/badge/pylint-9.59%2F10-brightgreen)](https://pylint.pycqa.org/)
+[![Pylint](https://img.shields.io/badge/pylint-9.63%2F10-brightgreen)](https://pylint.pycqa.org/)
 
 **egg** is a self-contained, portable, and executable document format for reproducible code, data, and results. Inspired by the egg metaphor—slow to build, instant to hatch—it aims to make notebooks in any language "just work" on any machine with zero configuration.
 

--- a/egg_cli.py
+++ b/egg_cli.py
@@ -118,6 +118,14 @@ def info(args: argparse.Namespace) -> None:
     print("Cells:")
     for cell in manifest.cells:
         print(f"  - {cell.language}: {cell.source}")
+    if manifest.dependencies:
+        print("Dependencies:")
+        for dep in manifest.dependencies:
+            print(f"  - {dep}")
+    if manifest.permissions:
+        print("Permissions:")
+        for perm, val in manifest.permissions.items():
+            print(f"  {perm}: {val}")
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 PyYAML
 pytest
+pytest-cov
 pre-commit
 ruff
 black

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -804,6 +804,35 @@ def test_info_subcommand(monkeypatch, tmp_path, capsys):
     assert "hello.R" in out
 
 
+def test_info_dependencies_permissions(monkeypatch, tmp_path, capsys):
+    """Advanced manifest fields should be listed by info."""
+    egg_path = tmp_path / "adv.egg"
+
+    # build using advanced manifest with deps and permissions
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "egg_cli.py",
+            "build",
+            "--manifest",
+            os.path.join("examples", "advanced_manifest.yaml"),
+            "--output",
+            str(egg_path),
+        ],
+    )
+    egg_cli.main()
+    capsys.readouterr()
+
+    monkeypatch.setattr(sys, "argv", ["egg_cli.py", "info", "--egg", str(egg_path)])
+    egg_cli.main()
+    out = capsys.readouterr().out
+    assert "Dependencies:" in out
+    assert "python:3.11" in out
+    assert "Permissions:" in out
+    assert "network: True" in out
+
+
 def test_hatch_missing_egg(monkeypatch):
     missing = Path("nope.egg")
     monkeypatch.setattr(sys, "argv", ["egg_cli.py", "hatch", "--egg", str(missing)])


### PR DESCRIPTION
## Summary
- fix pytest hook in pre-commit and install pytest-cov
- show dependencies and permissions in `egg info`
- test advanced manifest fields in CLI

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_6850a698d2348328b5b6ea17464b8584