### PR TITLE
Add plugin entry points and loader

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,24 @@ pre-commit run --all-files
 These commands format the code, perform static analysis and run the test suite.
 Refer to [CONTRIBUTING.md](CONTRIBUTING.md) for details on style guidelines.
 
+### Plug-in Development
+
+Egg's functionality can be extended through Python entry points. Create a
+`register()` function in your module and list it under the appropriate group in
+`pyproject.toml`:
+
+```toml
+[project.entry-points."egg.runtimes"]
+ruby = "mypkg.ruby_plugin:register"
+
+[project.entry-points."egg.agents"]
+hello = "mypkg.hello_agent:register"
+```
+
+Runtime plug-ins should return a mapping of language names to command lists.
+Agent plug-ins run for their side effects and may modify the CLI or agents.
+Both types are discovered by `egg.utils.load_plugins()` when the CLI starts.
+
 ---
 
 See [FORMAT.md](FORMAT.md) for the file structure produced by these agents.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # 🥚 egg file format
 
-[![Coverage](https://img.shields.io/badge/coverage-98%25-brightgreen)](https://img.shields.io)
-[![Pylint](https://img.shields.io/badge/pylint-9.63%2F10-brightgreen)](https://pylint.pycqa.org/)
+[![Coverage](https://img.shields.io/badge/coverage-97%25-brightgreen)](https://img.shields.io)
+[![Pylint](https://img.shields.io/badge/pylint-9.57%2F10-brightgreen)](https://pylint.pycqa.org/)
 
 **egg** is a self-contained, portable, and executable document format for reproducible code, data, and results. Inspired by the egg metaphor—slow to build, instant to hatch—it aims to make notebooks in any language "just work" on any machine with zero configuration.
 

--- a/egg_cli.py
+++ b/egg_cli.py
@@ -16,7 +16,7 @@ from egg.manifest import load_manifest
 from egg.sandboxer import prepare_images
 from egg.runtime_fetcher import fetch_runtime_blocks
 from egg.precompute import precompute_cells
-from egg.utils import get_lang_command
+from egg.utils import get_lang_command, load_plugins
 
 
 __version__ = "0.1.0"
@@ -132,6 +132,8 @@ def main(argv: list[str] | None = None) -> None:
     """Entry point for the ``egg`` command line interface."""
     if argv is None:  # pragma: no cover - convenience for __main__
         argv = sys.argv[1:]
+
+    load_plugins()
 
     global_parser = argparse.ArgumentParser(add_help=False)
     global_parser.add_argument(

--- a/examples/hello_agent.py
+++ b/examples/hello_agent.py
@@ -1,0 +1,7 @@
+"""Example agent plug-in that logs a greeting at startup."""
+
+import logging
+
+
+def register():
+    logging.getLogger(__name__).info("Hello from plug-in")

--- a/examples/ruby_plugin.py
+++ b/examples/ruby_plugin.py
@@ -1,0 +1,6 @@
+"""Example runtime plug-in adding Ruby support."""
+
+
+def register():
+    """Return a mapping for Ruby language support."""
+    return {"ruby": ["ruby"]}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,10 @@ license = "MIT"
 [project.scripts]
 egg = "egg_cli:main"
 
+[project.entry-points."egg.agents"]
+
+[project.entry-points."egg.runtimes"]
+
 [tool.setuptools]
 packages = ["egg"]
 py-modules = ["egg_cli"]


### PR DESCRIPTION
## Summary
- expose empty agent & runtime entry points
- load runtime and agent plugins via `egg.utils.load_plugins`
- call plugin loader at CLI startup
- document plugin development
- add example plugin modules

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850a9133c84832885abae5af892bae5