### PR TITLE
Ensure compose creates output dirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # 🥚 egg file format
 
-[![Coverage](https://img.shields.io/badge/coverage-98%25-brightgreen)](https://img.shields.io)
-[![Pylint](https://img.shields.io/badge/pylint-9.65%2F10-brightgreen)](https://pylint.pycqa.org/)
+[![Coverage](https://img.shields.io/badge/coverage-96%25-brightgreen)](https://img.shields.io)
+[![Pylint](https://img.shields.io/badge/pylint-9.62%2F10-brightgreen)](https://pylint.pycqa.org/)
 
 **egg** is a self-contained, portable, and executable document format for reproducible code, data, and results. Inspired by the egg metaphor—slow to build, instant to hatch—it aims to make notebooks in any language "just work" on any machine with zero configuration.
 

--- a/egg/composer.py
+++ b/egg/composer.py
@@ -39,6 +39,7 @@ def compose(
     """
     manifest_path = Path(manifest_path)
     output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
 
     manifest = load_manifest(manifest_path)
 

--- a/tests/test_composer.py
+++ b/tests/test_composer.py
@@ -37,3 +37,23 @@ dependencies:
     output = tmp_path / "demo.egg"
     with pytest.raises(ValueError):
         compose(manifest, output, dependencies=[dep1, dep2])
+
+
+def test_compose_creates_output_dir(tmp_path: Path) -> None:
+    src = tmp_path / "code.py"
+    src.write_text("print('hi')\n")
+
+    manifest = tmp_path / "manifest.yaml"
+    manifest.write_text(
+        """
+name: Example
+description: desc
+cells:
+  - language: python
+    source: code.py
+"""
+    )
+
+    output = tmp_path / "new" / "demo.egg"
+    compose(manifest, output)
+    assert output.is_file()


### PR DESCRIPTION
## Summary
- create the output directory if needed when composing an egg
- test composing to a file in a fresh directory
- update badges via pre-commit

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850ac89c5d88328af526ad5d6cca502