### PR TITLE
Improve load_hashes validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # 🥚 egg file format
 
-[![Coverage](https://img.shields.io/badge/coverage-96%25-cyan)](https://img.shields.io)
-[![Pylint](https://img.shields.io/badge/pylint-9.62%2F10-green)](https://pylint.pycqa.org/)
+[![Coverage](https://img.shields.io/badge/coverage-98%25-cyan)](https://img.shields.io)
+[![Pylint](https://img.shields.io/badge/pylint-9.45%2F10-green)](https://pylint.pycqa.org/)
 
 **egg** is a self-contained, portable, and executable document format for reproducible code, data, and results. Inspired by the egg metaphor—slow to build, instant to hatch—it aims to make notebooks in any language "just work" on any machine with zero configuration.
 

--- a/egg/hashing.py
+++ b/egg/hashing.py
@@ -86,6 +86,11 @@ def load_hashes(path: Path) -> Dict[str, str]:
         return {}
     if not isinstance(data, dict):
         raise ValueError("hashes.yaml must contain a mapping")
+
+    for key, value in data.items():
+        if not isinstance(key, str) or not isinstance(value, str):
+            raise ValueError("hashes.yaml keys and values must be strings")
+
     return data
 
 

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -67,6 +67,14 @@ def test_load_hashes_requires_mapping(tmp_path: Path) -> None:
         load_hashes(path)
 
 
+def test_load_hashes_non_string_value(tmp_path: Path) -> None:
+    """Non-string hash values should raise ValueError."""
+    path = tmp_path / "hashes.yaml"
+    path.write_text("foo: 1\n")
+    with pytest.raises(ValueError):
+        load_hashes(path)
+
+
 def test_verify_archive_with_extra_file(tmp_path: Path) -> None:
     """Archives containing files not listed in hashes.yaml should fail."""
     output = tmp_path / "demo.egg"


### PR DESCRIPTION
## Summary
- validate key/value types when loading `hashes.yaml`
- test that a non-string value raises `ValueError`
- update README badges via pre-commit

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850b19e68bc8328b3ac2d126990d87f