### PR TITLE
Add signing key option to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # 🥚 egg file format
 
-[![Coverage](https://img.shields.io/badge/coverage-96%25-cyan)](https://img.shields.io)
-[![Pylint](https://img.shields.io/badge/pylint-9.62%2F10-green)](https://pylint.pycqa.org/)
+[![Coverage](https://img.shields.io/badge/coverage-98%25-cyan)](https://img.shields.io)
+[![Pylint](https://img.shields.io/badge/pylint-9.45%2F10-green)](https://pylint.pycqa.org/)
 
 **egg** is a self-contained, portable, and executable document format for reproducible code, data, and results. Inspired by the egg metaphor—slow to build, instant to hatch—it aims to make notebooks in any language "just work" on any machine with zero configuration.
 
@@ -40,13 +40,13 @@ For a Julia example see `examples/julia_manifest.yaml`.
 ## CLI Overview
 
 ```bash
-egg build  --manifest <file> --output <egg> [--precompute]
+egg build  --manifest <file> --output <egg> [--precompute] [--signing-key <file>]
 egg hatch  --egg <egg> [--no-sandbox]
-egg verify --egg <egg>
+egg verify --egg <egg> [--signing-key <file>]
 egg info   --egg <egg>
 ```
 
-Use `egg <command> -h` to see all options. Runtime commands can be overridden with `EGG_CMD_PYTHON`, `EGG_CMD_R`, or `EGG_CMD_BASH`. The signing key for `hashes.yaml` can be changed via `EGG_SIGNING_KEY`.
+Use `egg <command> -h` to see all options. Runtime commands can be overridden with `EGG_CMD_PYTHON`, `EGG_CMD_R`, or `EGG_CMD_BASH`. The signing key for `hashes.yaml` can be changed with `--signing-key` or the `EGG_SIGNING_KEY` environment variable.
 
 ### Testing
 

--- a/egg/composer.py
+++ b/egg/composer.py
@@ -11,7 +11,12 @@ from typing import Iterable, List
 from .manifest import load_manifest, Manifest
 
 
-from .hashing import compute_hashes, write_hashes_file, sign_hashes, SIGNING_KEY
+from .hashing import (
+    compute_hashes,
+    write_hashes_file,
+    sign_hashes,
+    SIGNING_KEY,
+)
 
 
 def _collect_sources(manifest: Manifest) -> Iterable[Path]:
@@ -25,6 +30,7 @@ def compose(
     output_path: Path | str,
     *,
     dependencies: Iterable[Path] | None = None,
+    signing_key: bytes | None = None,
 ) -> None:
     """Compose an egg archive by zipping manifest, sources, and dependencies.
 
@@ -36,6 +42,8 @@ def compose(
         Destination ``.egg`` archive path.
     dependencies : Iterable[Path] | None, optional
         Additional files to include under ``runtime/``.
+    signing_key : bytes | None, optional
+        Key used to sign ``hashes.yaml``. Defaults to ``SIGNING_KEY``.
     """
     manifest_path = Path(manifest_path)
     output_path = Path(output_path)
@@ -83,7 +91,8 @@ def compose(
         hashes = compute_hashes(copied, base_dir=tmpdir_path)
         hashes_path = tmpdir_path / "hashes.yaml"
         write_hashes_file(hashes, hashes_path)
-        sig = sign_hashes(hashes_path, key=SIGNING_KEY)
+        key = SIGNING_KEY if signing_key is None else signing_key
+        sig = sign_hashes(hashes_path, key=key)
         sig_path = tmpdir_path / "hashes.sig"
         sig_path.write_text(sig, encoding="utf-8")
         copied.extend([hashes_path, sig_path])


### PR DESCRIPTION
## Summary
- allow specifying signing key file on the build and verify commands
- use signing key when composing and verifying archives
- document the new `--signing-key` option
- test the CLI with a custom signing key

## Testing
- `pip install .`
- `pip install -r requirements-dev.txt`
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_6850b19d7bb08328aa34eb7cdf7ee183