### PR TITLE
Handle runtime container download errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # 🥚 egg file format
 
-[![Coverage](https://img.shields.io/badge/coverage-96%25-cyan)](https://img.shields.io)
-[![Pylint](https://img.shields.io/badge/pylint-9.62%2F10-green)](https://pylint.pycqa.org/)
+[![Coverage](https://img.shields.io/badge/coverage-98%25-cyan)](https://img.shields.io)
+[![Pylint](https://img.shields.io/badge/pylint-9.45%2F10-green)](https://pylint.pycqa.org/)
 
 **egg** is a self-contained, portable, and executable document format for reproducible code, data, and results. Inspired by the egg metaphor—slow to build, instant to hatch—it aims to make notebooks in any language "just work" on any machine with zero configuration.
 


### PR DESCRIPTION
## Summary
- add error handling for HTTP container downloads
- update README badges via pre-commit
- test failure when container download fails

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_6850b19f5a008328873b21d1eec542e9