### PR TITLE
Cache platform.system call in prepare_images

### DIFF
--- a/egg/sandboxer.py
+++ b/egg/sandboxer.py
@@ -93,6 +93,7 @@ def prepare_images(
         Mapping of language name to created image directory path.
     """
     check_platform()
+    system = platform.system()
     if base_dir is None:
         base = Path(tempfile.mkdtemp())
     else:
@@ -103,7 +104,7 @@ def prepare_images(
         if lang in images:
             continue  # pragma: no cover
         img_dir = base / f"{lang}-image"
-        if platform.system() == "Linux":
+        if system == "Linux":
             build_microvm_image(lang, img_dir)
         else:
             build_container_image(lang, img_dir)


### PR DESCRIPTION
## Summary
- optimize OS detection in `prepare_images`
- call `platform.system()` only once and reuse the value

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_685969beb0408328873c24d8b88a0616