### PR TITLE
Add path validation tests

### DIFF
--- a/tests/test_composer.py
+++ b/tests/test_composer.py
@@ -57,3 +57,13 @@ cells:
     output = tmp_path / "new" / "demo.egg"
     compose(manifest, output)
     assert output.is_file()
+
+
+def test_normalize_source_traversal(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        _normalize_source("../evil.py", tmp_path)
+
+
+def test_normalize_source_valid_relative(tmp_path: Path) -> None:
+    normalized = _normalize_source("sub/../good.py", tmp_path)
+    assert normalized == "good.py"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import importlib
+from pathlib import Path
 
 sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
 
@@ -77,3 +78,15 @@ def test_load_plugins_legacy(monkeypatch):
     assert runtime_called == [True]
     assert agent_called == [True]
     assert mod.DEFAULT_LANG_COMMANDS["ruby"] == ["ruby"]
+
+
+def test_is_relative_to_inside(tmp_path: Path) -> None:
+    base = tmp_path / "base"
+    inner = base / "x" / "y.txt"
+    assert utils._is_relative_to(inner, base)
+
+
+def test_is_relative_to_outside(tmp_path: Path) -> None:
+    base = tmp_path / "base"
+    other = tmp_path / "other" / "z.txt"
+    assert not utils._is_relative_to(other, base)


### PR DESCRIPTION
## Summary
- test `_is_relative_to` for paths inside/outside base
- ensure `_normalize_source` blocks traversal and allows valid paths

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_685969bc3bd88328b71e259bf232ee87