### PR TITLE
Add dozen-language manifest example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ egg info --egg demo.egg
 ```
 
 For a Julia example see `examples/julia_manifest.yaml`.
+A full manifest mixing twelve languages is provided in `examples/dozen_manifest.yaml`.
 
 ## Writing Plug-ins
 

--- a/examples/dozen_manifest.yaml
+++ b/examples/dozen_manifest.yaml
@@ -1,0 +1,27 @@
+name: "Dozen Languages"
+description: "Showcase mixing twelve languages in one egg"
+cells:
+  - language: python
+    source: hello.py
+  - language: r
+    source: hello.R
+  - language: bash
+    source: say.sh
+  - language: julia
+    source: julia_example.jl
+  - language: ruby
+    source: hello.rb
+  - language: perl
+    source: hello.pl
+  - language: lua
+    source: hello.lua
+  - language: php
+    source: hello.php
+  - language: javascript
+    source: hello.js
+  - language: go
+    source: hello.go
+  - language: rust
+    source: hello.rs
+  - language: tcl
+    source: hello.tcl

--- a/examples/hello.go
+++ b/examples/hello.go
@@ -1,0 +1,3 @@
+package main
+import "fmt"
+func main() { fmt.Println("Hello from Go") }

--- a/examples/hello.js
+++ b/examples/hello.js
@@ -1,0 +1,1 @@
+console.log('Hello from JavaScript');

--- a/examples/hello.lua
+++ b/examples/hello.lua
@@ -1,0 +1,1 @@
+print('Hello from Lua')

--- a/examples/hello.php
+++ b/examples/hello.php
@@ -1,0 +1,1 @@
+<?php echo "Hello from PHP\n"; ?>

--- a/examples/hello.pl
+++ b/examples/hello.pl
@@ -1,0 +1,1 @@
+print "Hello from Perl\n";

--- a/examples/hello.rb
+++ b/examples/hello.rb
@@ -1,0 +1,1 @@
+puts 'Hello from Ruby'

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello from Rust");
+}

--- a/examples/hello.tcl
+++ b/examples/hello.tcl
@@ -1,0 +1,1 @@
+puts "Hello from Tcl"


### PR DESCRIPTION
## Summary
- provide a new example manifest demonstrating 12 languages
- add simple hello scripts for Go, JavaScript, Lua, PHP, Perl, Ruby, Rust and Tcl
- mention the new example in the README

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_68680a4cd7288328b6e9ca170dd2ae2c