### PR TITLE
Add languages subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # 🥚 egg file format
 
 [![Coverage](https://img.shields.io/badge/coverage-100%25-cyan)](https://img.shields.io)
-[![Pylint](https://img.shields.io/badge/pylint-9.39%2F10-green)](https://pylint.pycqa.org/)
+[![Pylint](https://img.shields.io/badge/pylint-9.38%2F10-green)](https://pylint.pycqa.org/)
 
 **egg** is a self-contained, portable, and executable document format for reproducible code, data, and results. Inspired by the egg metaphor—slow to build, instant to hatch—it aims to make notebooks in any language "just work" on any machine with zero configuration.
 
@@ -60,6 +60,7 @@ egg build  --manifest <file> --output <egg> [--precompute] [--signing-key <file>
 egg hatch  --egg <egg> [--no-sandbox]
 egg verify --egg <egg> [--signing-key <file>]
 egg info   --egg <egg>
+egg languages
 ```
 
 Use `egg <command> -h` to see all options. Runtime commands can be overridden with `EGG_CMD_PYTHON`, `EGG_CMD_R`, or `EGG_CMD_BASH`. The signing key for `hashes.yaml` can be changed with `--signing-key` or the `EGG_SIGNING_KEY` environment variable.

--- a/egg_cli.py
+++ b/egg_cli.py
@@ -18,7 +18,7 @@ from egg.manifest import load_manifest
 from egg.sandboxer import prepare_images
 from egg.runtime_fetcher import fetch_runtime_blocks
 from egg.precompute import precompute_cells
-from egg.utils import get_lang_command, load_plugins
+from egg.utils import DEFAULT_LANG_COMMANDS, get_lang_command, load_plugins
 
 
 __version__ = "0.1.0"
@@ -148,6 +148,13 @@ def info(args: argparse.Namespace) -> None:
             print(f"  {perm}: {val}")
 
 
+def languages(args: argparse.Namespace) -> None:
+    """Print supported language identifiers."""
+    load_plugins()
+    for lang in sorted(DEFAULT_LANG_COMMANDS):
+        print(lang)
+
+
 def main(argv: list[str] | None = None) -> None:
     """Entry point for the ``egg`` command line interface."""
     if argv is None:  # pragma: no cover - convenience for __main__
@@ -246,6 +253,11 @@ def main(argv: list[str] | None = None) -> None:
         help="Egg file to inspect",
     )
     parser_info.set_defaults(func=info)
+
+    parser_langs = subparsers.add_parser(
+        "languages", help="List supported languages", parents=[global_parser]
+    )
+    parser_langs.set_defaults(func=languages)
 
     args, _ = parser.parse_known_args(argv)
     extras, _ = global_parser.parse_known_args(argv)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1127,3 +1127,11 @@ cells:
     assert "Author: Bob" in out
     assert "License: MIT" in out
     assert "Created: 2024-01-01" in out
+
+
+def test_languages_command(monkeypatch, capsys):
+    """The languages command should list plug-in languages."""
+    monkeypatch.setattr(sys, "argv", ["egg_cli.py", "languages"])
+    egg_cli.main()
+    out = set(capsys.readouterr().out.splitlines())
+    assert {"python", "r", "bash", "ruby"} <= out


### PR DESCRIPTION
## Summary
- add `languages` subcommand that lists supported language identifiers
- document the command in README
- test new CLI behaviour

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_686d5bdc96f08328a72feb80adbe5cd5