### PR TITLE
Improve Firecracker sandbox support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # 🥚 egg file format
 
 [![Coverage](https://img.shields.io/badge/coverage-100%25-cyan)](https://img.shields.io)
-[![Pylint](https://img.shields.io/badge/pylint-9.39%2F10-green)](https://pylint.pycqa.org/)
+[![Pylint](https://img.shields.io/badge/pylint-9.40%2F10-green)](https://pylint.pycqa.org/)
 
 **egg** is a self-contained, portable, and executable document format for reproducible code, data, and results. Inspired by the egg metaphor—slow to build, instant to hatch—it aims to make notebooks in any language "just work" on any machine with zero configuration.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,6 +22,9 @@ mechanisms built into the format and CLI tools.
   root filesystem.
 - During `egg hatch`, the sandboxer prepares a container image (or placeholder
   `microvm.conf` in this prototype) for every runtime.
+- Firecracker requires a Linux host with KVM enabled and the `firecracker`
+  binary installed. Non-Linux platforms automatically fall back to Docker
+  containers for isolation.
 - Passing `--no-sandbox` disables isolation and should only be used for testing
   trusted eggs.
 


### PR DESCRIPTION
## Summary
- create minimal VM files in `build_microvm_image`
- call Firecracker with `--no-api`
- fall back to Docker on non-Linux platforms when launching containers
- test sandbox helper functions via CLI tests
- document required Firecracker setup

## Testing
- `pip install .`
- `pip install -r requirements-dev.txt`
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_686d5bda4d648328a9c26a178363d69f