### PR TITLE
Switch to Ed25519 signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # 🥚 egg file format
 
-[![Coverage](https://img.shields.io/badge/coverage-100%25-cyan)](https://img.shields.io)
-[![Pylint](https://img.shields.io/badge/pylint-9.39%2F10-green)](https://pylint.pycqa.org/)
+[![Coverage](https://img.shields.io/badge/coverage-99%25-cyan)](https://img.shields.io)
+[![Pylint](https://img.shields.io/badge/pylint-9.40%2F10-green)](https://pylint.pycqa.org/)
 
 **egg** is a self-contained, portable, and executable document format for reproducible code, data, and results. Inspired by the egg metaphor—slow to build, instant to hatch—it aims to make notebooks in any language "just work" on any machine with zero configuration.
 
@@ -56,13 +56,13 @@ egg -vv --help  # shows "[plugins] loaded ..." messages
 ## CLI Overview
 
 ```bash
-egg build  --manifest <file> --output <egg> [--precompute] [--signing-key <file>]
-egg hatch  --egg <egg> [--no-sandbox]
-egg verify --egg <egg> [--signing-key <file>]
-egg info   --egg <egg>
+egg build  --manifest <file> --output <egg> [--precompute] [--private-key <file>]
+egg hatch  --egg <egg> [--no-sandbox] [--public-key <file>]
+egg verify --egg <egg> [--public-key <file>]
+egg info   --egg <egg> [--public-key <file>]
 ```
 
-Use `egg <command> -h` to see all options. Runtime commands can be overridden with `EGG_CMD_PYTHON`, `EGG_CMD_R`, or `EGG_CMD_BASH`. The signing key for `hashes.yaml` can be changed with `--signing-key` or the `EGG_SIGNING_KEY` environment variable.
+Use `egg <command> -h` to see all options. Runtime commands can be overridden with `EGG_CMD_PYTHON`, `EGG_CMD_R`, or `EGG_CMD_BASH`. Keys for `hashes.yaml` can be supplied via `--private-key`/`--public-key` or the `EGG_PRIVATE_KEY`/`EGG_PUBLIC_KEY` environment variables.
 
 ### Testing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,7 +27,7 @@ mechanisms built into the format and CLI tools.
 
 ### Integrity & Authenticity
 - All blocks and assets are deterministically chunked, hashed, and optionally
-  signed during `egg build`.
+  signed with Ed25519 during `egg build`.
 - The manifest stores a chain of hashes and signatures for auditability.
 - Viewers verify the manifest and block hashes before executing any code.
 - Runtimes fetched from registries are pinned to specific hashes or signatures.

--- a/egg/composer.py
+++ b/egg/composer.py
@@ -15,7 +15,7 @@ from .hashing import (
     compute_hashes,
     write_hashes_file,
     sign_hashes,
-    SIGNING_KEY,
+    DEFAULT_PRIVATE_KEY,
 )
 
 
@@ -30,7 +30,7 @@ def compose(
     output_path: Path | str,
     *,
     dependencies: Iterable[Path] | None = None,
-    signing_key: bytes | None = None,
+    private_key: bytes | None = None,
 ) -> None:
     """Compose an egg archive by zipping manifest, sources, and dependencies.
 
@@ -42,8 +42,8 @@ def compose(
         Destination ``.egg`` archive path.
     dependencies : Iterable[Path] | None, optional
         Additional files to include under ``runtime/``.
-    signing_key : bytes | None, optional
-        Key used to sign ``hashes.yaml``. Defaults to ``SIGNING_KEY``.
+    private_key : bytes | None, optional
+        Private key used to sign ``hashes.yaml``. Defaults to ``DEFAULT_PRIVATE_KEY``.
     """
     manifest_path = Path(manifest_path)
     output_path = Path(output_path)
@@ -91,8 +91,8 @@ def compose(
         hashes = compute_hashes(copied, base_dir=tmpdir_path)
         hashes_path = tmpdir_path / "hashes.yaml"
         write_hashes_file(hashes, hashes_path)
-        key = SIGNING_KEY if signing_key is None else signing_key
-        sig = sign_hashes(hashes_path, key=key)
+        key = DEFAULT_PRIVATE_KEY if private_key is None else private_key
+        sig = sign_hashes(hashes_path, private_key=key)
         sig_path = tmpdir_path / "hashes.sig"
         sig_path.write_text(sig, encoding="utf-8")
         copied.extend([hashes_path, sig_path])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [{ name = "egg contributors" }]
 readme = "README.md"
 description = "CLI tools for the egg file format"
 requires-python = ">=3.8"
-dependencies = ["PyYAML>=6"]
+dependencies = ["PyYAML>=6", "PyNaCl>=1.5"]
 license = "MIT"
 
 [project.scripts]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 PyYAML
+PyNaCl
 pytest
 pytest-cov
 pre-commit


### PR DESCRIPTION
## Summary
- replace HMAC with Ed25519 signatures
- allow passing private/public keys via CLI
- update docs for new signing mechanism
- adjust tests for Ed25519

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_686d5bd91c6483289bf39824556c4f18