### PR TITLE
Validate permission key types in manifest loader

### DIFF
--- a/egg/manifest.py
+++ b/egg/manifest.py
@@ -98,9 +98,11 @@ def load_manifest(path: Path | str) -> Manifest:
             raise ValueError("'permissions' must be a mapping")
         permissions = {}
         for perm, val in permissions_data.items():
+            if not isinstance(perm, str):
+                raise ValueError(f"Permission key {perm!r} must be a string")
             if not isinstance(val, bool):
                 raise ValueError(f"Permission '{perm}' must be a boolean")
-            permissions[str(perm)] = val
+            permissions[perm] = val
 
     deps_data = data.get("dependencies")
     dependencies: List[str] | None

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -251,6 +251,23 @@ cells:
         load_manifest(path)
 
 
+def test_permission_key_must_be_string(tmp_path: Path) -> None:
+    path = tmp_path / "manifest.yaml"
+    path.write_text(
+        """
+name: Example
+description: desc
+permissions:
+  123: true
+cells:
+  - language: python
+    source: hello.py
+"""
+    )
+    with pytest.raises(ValueError, match="Permission key 123 must be a string"):
+        load_manifest(path)
+
+
 def test_manifest_with_dependencies(tmp_path: Path) -> None:
     path = tmp_path / "manifest.yaml"
     path.write_text(


### PR DESCRIPTION
## Summary
- ensure permission keys in manifest are strings
- test non-string permission keys

## Testing
- `pip install .`
- `pip install -r requirements-dev.txt`
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_689d22b871408328b8b2c3d28ee56f7e