### PR TITLE
Validate container config in sandboxer

### DIFF
--- a/egg/sandboxer.py
+++ b/egg/sandboxer.py
@@ -162,7 +162,15 @@ def launch_container(image_dir: Path) -> subprocess.CompletedProcess:
     """
 
     config = image_dir / "container.json"
-    language = json.loads(config.read_text())["language"]
+    if not config.is_file():
+        raise ValueError(f"missing container.json in {image_dir}")
+    try:
+        data = json.loads(config.read_text())
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid container.json in {image_dir}") from exc
+    if "language" not in data:
+        raise ValueError(f"container.json missing 'language' key in {image_dir}")
+    language = data["language"]
 
     if platform.system() == "Linux":
         cmd = ["runc", "run", language]

--- a/tests/test_sandboxer.py
+++ b/tests/test_sandboxer.py
@@ -5,6 +5,7 @@ from pathlib import Path
 sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
 
 from egg.manifest import Manifest, Cell  # noqa: E402
+from egg.sandboxer import launch_container  # noqa: E402
 import importlib
 import platform
 
@@ -46,3 +47,19 @@ def test_prepare_images_writes_config(
         config = path / conf_file
         assert config.is_file()
         assert config.read_text()
+
+
+def test_launch_container_missing_config(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="container.json"):
+        launch_container(tmp_path)
+
+
+@pytest.mark.parametrize(
+    "content, message", [("not json", "invalid"), ("{}", "language")]
+)
+def test_launch_container_corrupt_config(
+    tmp_path: Path, content: str, message: str
+) -> None:
+    (tmp_path / "container.json").write_text(content)
+    with pytest.raises(ValueError, match=message):
+        launch_container(tmp_path)


### PR DESCRIPTION
## Summary
- check `container.json` exists and includes a `language` field before launching
- add tests covering missing and corrupted container configuration

## Testing
- `pip install .`
- `pip install -r requirements-dev.txt`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_689d22b941f88328bdc75794f0e7d209