### PR TITLE
Validate runtime plugin mappings

### DIFF
--- a/egg/utils.py
+++ b/egg/utils.py
@@ -66,8 +66,24 @@ def load_plugins() -> None:
         try:
             handler = ep.load()
             extra = handler()
-            if isinstance(extra, dict):
-                DEFAULT_LANG_COMMANDS.update(extra)
+            if not isinstance(extra, dict):
+                logger.warning(
+                    "Runtime plug-in %s returned non-mapping %r", ep.name, type(extra)
+                )
+            else:
+                for lang, cmd in extra.items():
+                    if not (
+                        isinstance(lang, str)
+                        and isinstance(cmd, list)
+                        and all(isinstance(c, str) for c in cmd)
+                    ):
+                        logger.warning(
+                            "Runtime plug-in %s returned invalid mapping for %r",
+                            ep.name,
+                            lang,
+                        )
+                        continue
+                    DEFAULT_LANG_COMMANDS[lang] = cmd
             logger.debug("[plugins] loaded runtime %s", ep.name)
         except Exception as exc:  # pragma: no cover - defensive
             logger.warning("Failed loading runtime plug-in %s: %s", ep.name, exc)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -80,6 +80,22 @@ def test_load_plugins_legacy(monkeypatch):
     assert mod.DEFAULT_LANG_COMMANDS["ruby"] == ["ruby"]
 
 
+def test_load_plugins_invalid_runtime(monkeypatch, caplog):
+    mod = _reset_utils(monkeypatch)
+
+    def runtime():
+        return {"ruby": "ruby"}
+
+    eps = {mod.RUNTIME_PLUGIN_GROUP: [DummyEP("ruby", runtime)]}
+
+    monkeypatch.setattr(mod, "entry_points", lambda: eps)
+    with caplog.at_level("WARNING"):
+        mod.load_plugins()
+
+    assert "invalid mapping" in caplog.text
+    assert "ruby" not in mod.DEFAULT_LANG_COMMANDS
+
+
 def test_is_relative_to_inside(tmp_path: Path) -> None:
     base = tmp_path / "base"
     inner = base / "x" / "y.txt"


### PR DESCRIPTION
## Summary
- validate runtime plug-in extra mappings for expected dict[str, list[str]]
- warn and skip invalid runtime plug-in mappings
- test runtime plug-in validation with an invalid mapping

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_68a2693041e88328a13e0099bc0d865a