### PR TITLE
Add timeout option for precompute cells

### DIFF
--- a/egg/precompute.py
+++ b/egg/precompute.py
@@ -13,7 +13,9 @@ from .utils import get_lang_command
 from .hashing import sha256_file, write_hashes_file, load_hashes
 
 
-def precompute_cells(manifest_path: Path | str) -> List[Path]:
+def precompute_cells(
+    manifest_path: Path | str, timeout: float | None = None
+) -> List[Path]:
     """Execute each cell listed in ``manifest_path`` and capture stdout.
 
     For every cell in the manifest a new file ``<source>.out`` is written
@@ -51,6 +53,7 @@ def precompute_cells(manifest_path: Path | str) -> List[Path]:
                 stdout=out,
                 stderr=subprocess.PIPE,
                 text=True,
+                timeout=timeout,
             )
         if proc.returncode != 0:
             raise RuntimeError(f"Failed to precompute {src}:\n{proc.stderr}")

--- a/egg_cli.py
+++ b/egg_cli.py
@@ -46,7 +46,7 @@ def build(args: argparse.Namespace) -> None:
     deps = fetch_runtime_blocks(manifest)
 
     if args.precompute:
-        precompute_cells(manifest)
+        precompute_cells(manifest, timeout=args.precompute_timeout)
 
     priv: bytes | None = None
     if args.private_key:
@@ -246,6 +246,12 @@ def main(argv: list[str] | None = None) -> None:
         "--precompute",
         action="store_true",
         help="Execute cells and store outputs before composing",
+    )
+    parser_build.add_argument(
+        "--precompute-timeout",
+        type=float,
+        default=None,
+        help="Timeout in seconds for each precomputed cell",
     )
     parser_build.add_argument(
         "--private-key",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -53,7 +53,7 @@ def test_build_precompute(monkeypatch, tmp_path):
 
     called = []
 
-    def fake_precompute(path):
+    def fake_precompute(path, timeout=None):
         called.append(Path(path))
 
     monkeypatch.setattr(egg_cli, "precompute_cells", fake_precompute)

--- a/tests/test_precompute_extra.py
+++ b/tests/test_precompute_extra.py
@@ -10,6 +10,7 @@ sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
 from egg.utils import get_lang_command  # noqa: E402
 from egg.precompute import precompute_cells  # noqa: E402
 from egg.hashing import load_hashes, sha256_file  # noqa: E402
+import egg_cli  # noqa: E402
 
 
 def test_get_lang_command_env_override(monkeypatch):
@@ -182,3 +183,67 @@ def test_precompute_cache_invalidated(monkeypatch, tmp_path: Path) -> None:
     src.write_text("print('changed')\n")
     precompute_cells(manifest)
     assert len(calls) == 1
+
+
+def test_precompute_cells_passes_timeout(monkeypatch, tmp_path: Path) -> None:
+    src = tmp_path / "hello.py"
+    src.write_text("print('hi')\n")
+    manifest = _write_manifest(tmp_path / "manifest.yaml")
+
+    monkeypatch.setattr(shutil, "which", lambda c: c)
+
+    def fake_run(cmd, stdout=None, **kwargs):
+        assert kwargs.get("timeout") == 5.0
+        if stdout:
+            stdout.write("out\n")
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    precompute_cells(manifest, timeout=5.0)
+
+
+def test_precompute_cells_timeout_error(monkeypatch, tmp_path: Path) -> None:
+    src = tmp_path / "hello.py"
+    src.write_text("print('hi')\n")
+    manifest = _write_manifest(tmp_path / "manifest.yaml")
+
+    monkeypatch.setattr(shutil, "which", lambda c: c)
+
+    def fake_run(cmd, stdout=None, **kwargs):
+        raise subprocess.TimeoutExpired(cmd, kwargs.get("timeout"))
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        precompute_cells(manifest, timeout=0.1)
+
+
+def test_cli_precompute_timeout(monkeypatch, tmp_path: Path) -> None:
+    output = tmp_path / "demo.egg"
+    called: list[float | None] = []
+
+    def fake_precompute(path, timeout=None):
+        called.append(timeout)
+
+    monkeypatch.setattr(egg_cli, "precompute_cells", fake_precompute)
+    monkeypatch.setattr(egg_cli, "verify_archive", lambda *a, **kw: True)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "egg_cli.py",
+            "build",
+            "--manifest",
+            os.path.join("examples", "manifest.yaml"),
+            "--output",
+            str(output),
+            "--precompute",
+            "--precompute-timeout",
+            "7",
+        ],
+    )
+    egg_cli.main()
+
+    assert called == [7.0]
+    assert output.is_file()


### PR DESCRIPTION
## Summary
- allow `precompute_cells` to enforce a per-cell timeout
- expose `--precompute-timeout` flag in CLI and plumb through build
- test timeout handling and CLI propagation

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_68a2692df70883289812314d1c81cdea