### PR TITLE
Stream runtime downloads with checksum and size verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # 🥚 egg file format
 
 
-[![Coverage](https://img.shields.io/badge/coverage-99%25-cyan)](https://img.shields.io)
-[![Pylint](https://img.shields.io/badge/pylint-9.50%2F10-green)](https://pylint.pycqa.org/)
+[![Coverage](https://img.shields.io/badge/coverage-98%25-cyan)](https://img.shields.io)
+[![Pylint](https://img.shields.io/badge/pylint-9.48%2F10-green)](https://pylint.pycqa.org/)
 
 **egg** is a self-contained, portable, and executable document format for reproducible code, data, and results. Inspired by the egg metaphor—slow to build, instant to hatch—it aims to make notebooks in any language "just work" on any machine with zero configuration.
 

--- a/tests/test_runtime_fetcher.py
+++ b/tests/test_runtime_fetcher.py
@@ -119,6 +119,10 @@ dependencies:
     monkeypatch.setenv("EGG_REGISTRY_URL", "http://example.com")
 
     class Dummy(io.BytesIO):
+        def __init__(self, data: bytes) -> None:  # noqa: D401 - simple init
+            super().__init__(data)
+            self.headers = {}
+
         def __enter__(self):
             return self
 
@@ -360,6 +364,10 @@ dependencies:
     monkeypatch.setenv("EGG_DOWNLOAD_TIMEOUT", "12.5")
 
     class Dummy(io.BytesIO):
+        def __init__(self, data: bytes) -> None:  # noqa: D401 - simple init
+            super().__init__(data)
+            self.headers = {}
+
         def __enter__(self):
             return self
 

--- a/tests/test_runtime_fetcher_more.py
+++ b/tests/test_runtime_fetcher_more.py
@@ -1,8 +1,7 @@
-import os
+import hashlib
+import io
 import urllib.error
 from pathlib import Path
-import importlib
-import io
 
 import pytest
 
@@ -34,6 +33,10 @@ def test_download_container_timeout(monkeypatch, tmp_path: Path) -> None:
     dest = tmp_path / "python.img"
 
     class Dummy(io.BytesIO):
+        def __init__(self, data: bytes) -> None:  # noqa: D401 - simple init
+            super().__init__(data)
+            self.headers = {}
+
         def __enter__(self):
             return self
 
@@ -91,6 +94,7 @@ def test_download_container_interrupted(monkeypatch, tmp_path: Path) -> None:
         def __init__(self) -> None:  # noqa: D401 - simple init
             super().__init__(b"partial")
             self._sent = False
+            self.headers = {}
 
         def read(self, *args, **kwargs):  # noqa: D401 - match signature
             if not self._sent:
@@ -107,6 +111,65 @@ def test_download_container_interrupted(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setattr(rf, "urlopen", lambda *a, **kw: Failing())
     with pytest.raises(RuntimeError):
         rf._download_container("python:3.11", dest, "http://example.com")
+
+    assert not dest.exists()
+    assert not tmp.exists()
+
+
+def test_download_container_truncated(monkeypatch, tmp_path: Path) -> None:
+    dest = tmp_path / "python.img"
+    tmp = dest.with_suffix(".tmp")
+
+    class Truncated:
+        def __init__(self) -> None:  # noqa: D401 - simple init
+            self._io = io.BytesIO(b"data")
+            self.headers = {"Content-Length": "8"}
+
+        def read(self, *args, **kwargs):  # noqa: D401 - match signature
+            return self._io.read(*args, **kwargs)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            pass
+
+    monkeypatch.setattr(rf, "urlopen", lambda *a, **kw: Truncated())
+    with pytest.raises(RuntimeError, match="expected 8 bytes"):
+        rf._download_container("python:3.11", dest, "http://example.com")
+
+    assert not dest.exists()
+    assert not tmp.exists()
+
+
+def test_download_container_hash_failure(monkeypatch, tmp_path: Path) -> None:
+    dest = tmp_path / "python.img"
+    tmp = dest.with_suffix(".tmp")
+    data = b"data"
+    wrong = hashlib.sha256(b"other").hexdigest()
+
+    class Dummy:
+        def __init__(self) -> None:  # noqa: D401 - simple init
+            self._io = io.BytesIO(data)
+            self.headers = {"Content-Length": str(len(data))}
+
+        def read(self, *args, **kwargs):  # noqa: D401 - match signature
+            return self._io.read(*args, **kwargs)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            pass
+
+    monkeypatch.setattr(rf, "urlopen", lambda *a, **kw: Dummy())
+    with pytest.raises(RuntimeError, match="Checksum mismatch"):
+        rf._download_container(
+            "python:3.11",
+            dest,
+            "http://example.com",
+            expected_digest=wrong,
+        )
 
     assert not dest.exists()
     assert not tmp.exists()


### PR DESCRIPTION
## Summary
- Stream runtime container downloads in chunks while tracking bytes and computing a SHA256 digest
- Verify Content-Length and optional expected digest to detect truncation or tampering
- Add tests for truncated downloads and checksum mismatches

## Testing
- `pre-commit run --all-files`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a60edb46908328baa776522553a605