### PR TITLE
Check for duplicate entries in archives

### DIFF
--- a/egg/hashing.py
+++ b/egg/hashing.py
@@ -186,8 +186,13 @@ def verify_archive(archive: Path, *, public_key: bytes | None = None) -> bool:
             if hashlib.sha256(data).hexdigest() != expected:
                 return False
 
-        # Ensure no unverified files are present in the archive
-        names = set(zf.namelist())
+        # Ensure no unverified files are present in the archive and there are no
+        # duplicate entries. ``ZipFile.namelist`` returns a list which may
+        # contain duplicates, so check that before converting to a ``set``.
+        names_list = zf.namelist()
+        if len(names_list) != len(set(names_list)):
+            return False
+        names = set(names_list)
         names.discard("hashes.yaml")
         names.discard("hashes.sig")
         if names != set(hashes.keys()):


### PR DESCRIPTION
## Summary
- detect and reject duplicate file names in verify_archive

## Testing
- `pip install .`
- `pip install -r requirements-dev.txt`
- `pre-commit run --all-files` *(fails: tests/test_runtime_fetcher_more.py::test_download_container_repo - AttributeError: 'Dummy' object has no attribute 'headers')*

------
https://chatgpt.com/codex/tasks/task_e_68af0cfbacdc8328ad3550bf2f29824a