### PR TITLE
Detect sanitized runtime filename conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 
 [![Coverage](https://img.shields.io/badge/coverage-98%25-cyan)](https://img.shields.io)
-[![Pylint](https://img.shields.io/badge/pylint-9.48%2F10-green)](https://pylint.pycqa.org/)
+[![Pylint](https://img.shields.io/badge/pylint-9.46%2F10-green)](https://pylint.pycqa.org/)
 
 
 **egg** is a self-contained, portable, and executable document format for reproducible code, data, and results. Inspired by the egg metaphor—slow to build, instant to hatch—it aims to make notebooks in any language "just work" on any machine with zero configuration.


### PR DESCRIPTION
## Summary
- prevent runtime filename collisions by tracking sanitized container names and erroring on duplicates
- handle downloads that omit a `headers` attribute

## Testing
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68af0cfb17988328ae29c63a4a5cbdf9