### PR TITLE
chore: remove unused os import

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 
 [![Coverage](https://img.shields.io/badge/coverage-98%25-cyan)](https://img.shields.io)
-[![Pylint](https://img.shields.io/badge/pylint-9.47%2F10-green)](https://pylint.pycqa.org/)
+[![Pylint](https://img.shields.io/badge/pylint-9.48%2F10-green)](https://pylint.pycqa.org/)
 
 
 **egg** is a self-contained, portable, and executable document format for reproducible code, data, and results. Inspired by the egg metaphor—slow to build, instant to hatch—it aims to make notebooks in any language "just work" on any machine with zero configuration.

--- a/egg_cli.py
+++ b/egg_cli.py
@@ -2,7 +2,6 @@
 
 import argparse
 import logging
-import os
 import shutil
 import subprocess
 import sys


### PR DESCRIPTION
## Summary
- remove unused os import from CLI
- refresh Pylint badge via pre-commit update-badges hook

## Testing
- `pip install .`
- `pip install -r requirements-dev.txt`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68b1eac2cc808328821203ee4ac6cee3