### PR TITLE
Verify cached container digests before reuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 
 [![Coverage](https://img.shields.io/badge/coverage-98%25-cyan)](https://img.shields.io)
-[![Pylint](https://img.shields.io/badge/pylint-9.47%2F10-green)](https://pylint.pycqa.org/)
+[![Pylint](https://img.shields.io/badge/pylint-9.48%2F10-green)](https://pylint.pycqa.org/)
 
 
 **egg** is a self-contained, portable, and executable document format for reproducible code, data, and results. Inspired by the egg metaphor—slow to build, instant to hatch—it aims to make notebooks in any language "just work" on any machine with zero configuration.


### PR DESCRIPTION
## Summary
- validate cached container images against expected digest and refresh when missing or mismatched
- expand tests for cache verification and refresh logic
- update README badge via pre-commit

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_68b1eabcc08c8328903070f9b1b8c083