### PR TITLE
Allow composer dependency paths as strings

### DIFF
--- a/egg/composer.py
+++ b/egg/composer.py
@@ -29,7 +29,7 @@ def compose(
     manifest_path: Path | str,
     output_path: Path | str,
     *,
-    dependencies: Iterable[Path] | None = None,
+    dependencies: Iterable[Path | str] | None = None,
     private_key: bytes | None = None,
 ) -> None:
     """Compose an egg archive by zipping manifest, sources, and dependencies.
@@ -40,7 +40,7 @@ def compose(
         Path to the manifest YAML file describing sources.
     output_path : Path | str
         Destination ``.egg`` archive path.
-    dependencies : Iterable[Path] | None, optional
+    dependencies : Iterable[Path | str] | None, optional
         Additional files to include under ``runtime/``.
     private_key : bytes | None, optional
         Private key used to sign ``hashes.yaml``. Defaults to ``DEFAULT_PRIVATE_KEY``.
@@ -77,15 +77,17 @@ def compose(
         seen_runtime: set[str] = set()
         if dependencies:
             for dep in dependencies:
-                if isinstance(dep, Path):
-                    dest_name = dep.name
-                    if dest_name in seen_runtime:
-                        raise ValueError(f"Duplicate dependency filename: {dest_name}")
-                    seen_runtime.add(dest_name)
-                    dest = runtime_dir / dest_name
-                    dest.parent.mkdir(parents=True, exist_ok=True)
-                    shutil.copy2(dep, dest)
-                    copied.append(dest)
+                if isinstance(dep, str) and ":" in dep:
+                    continue
+                dep = Path(dep)
+                dest_name = dep.name
+                if dest_name in seen_runtime:
+                    raise ValueError(f"Duplicate dependency filename: {dest_name}")
+                seen_runtime.add(dest_name)
+                dest = runtime_dir / dest_name
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(dep, dest)
+                copied.append(dest)
 
         # write hashes file and signature
         hashes = compute_hashes(copied, base_dir=tmpdir_path)

--- a/tests/test_composer.py
+++ b/tests/test_composer.py
@@ -1,4 +1,5 @@
 import pytest
+import zipfile
 from pathlib import Path
 from egg.manifest import _normalize_source
 from egg.composer import compose
@@ -57,6 +58,33 @@ cells:
     output = tmp_path / "new" / "demo.egg"
     compose(manifest, output)
     assert output.is_file()
+
+
+def test_string_runtime_dependency_included(tmp_path: Path) -> None:
+    dep = tmp_path / "python.img"
+    dep.write_text("py")
+
+    src = tmp_path / "code.py"
+    src.write_text("print('hi')\n")
+
+    manifest = tmp_path / "manifest.yaml"
+    manifest.write_text(
+        """
+name: Example
+description: desc
+cells:
+  - language: python
+    source: code.py
+dependencies:
+  - python.img
+"""
+    )
+
+    output = tmp_path / "demo.egg"
+    compose(manifest, output, dependencies=[str(dep)])
+
+    with zipfile.ZipFile(output) as zf:
+        assert "runtime/python.img" in zf.namelist()
 
 
 def test_normalize_source_traversal(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Let `composer.compose` accept dependency paths given as strings
- Skip container-style dependency names when composing archives
- Test that string dependency paths are bundled into the output egg

## Testing
- `pip install .`
- `pip install -r requirements-dev.txt`
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_68b9b788abbc83289cc04603f42d9a97