### PR TITLE
feat: allow overriding runtime fetcher user agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 
 [![Coverage](https://img.shields.io/badge/coverage-98%25-cyan)](https://img.shields.io)
-[![Pylint](https://img.shields.io/badge/pylint-9.50%2F10-green)](https://pylint.pycqa.org/)
+[![Pylint](https://img.shields.io/badge/pylint-9.49%2F10-green)](https://pylint.pycqa.org/)
 
 
 **egg** is a self-contained, portable, and executable document format for reproducible code, data, and results. Inspired by the egg metaphor—slow to build, instant to hatch—it aims to make notebooks in any language "just work" on any machine with zero configuration.

--- a/egg/runtime_fetcher.py
+++ b/egg/runtime_fetcher.py
@@ -12,7 +12,7 @@ import hashlib
 import logging
 import os
 from urllib.parse import quote
-from urllib.request import urlopen
+from urllib.request import Request, urlopen
 from urllib.error import URLError, HTTPError
 import socket
 from pathlib import Path, PurePosixPath
@@ -52,6 +52,7 @@ def _download_container(
     timeout: float | None = None,
     *,
     expected_digest: str | None = None,
+    user_agent: str = "egg-runtime-fetcher",
 ) -> Path:
     """Download ``image`` from ``base_url`` to ``dest``.
 
@@ -66,6 +67,9 @@ def _download_container(
         digest are trusted; missing or mismatched digests trigger a
         re-download. After downloading, if the checksum does not match,
         ``RuntimeError`` is raised.
+    user_agent : str, optional
+        ``User-Agent`` header sent with the download request. Defaults to
+        ``"egg-runtime-fetcher"``.
 
     A ``ValueError`` is raised if ``dest`` resolves outside its parent
     directory.  This prevents a malicious symlink from redirecting the
@@ -109,8 +113,9 @@ def _download_container(
     url = f"{base_url.rstrip('/')}/{quote(image)}.img"
     logger.info("[runtime_fetcher] downloading %s -> %s", url, dest)
     tmp = dest.with_suffix(".tmp")
+    req = Request(url, headers={"User-Agent": user_agent})
     try:
-        with urlopen(url, timeout=timeout) as resp, open(tmp, "wb") as fh:
+        with urlopen(req, timeout=timeout) as resp, open(tmp, "wb") as fh:
             # ``urlopen`` responses provide a ``headers`` mapping. Test
             # doubles used in this project may omit the attribute, so fall back
             # to an empty mapping to avoid ``AttributeError``.

--- a/tests/test_runtime_fetcher.py
+++ b/tests/test_runtime_fetcher.py
@@ -279,7 +279,7 @@ dependencies:
 
     monkeypatch.setenv("EGG_REGISTRY_URL", "http://example.com")
 
-    def fail(url, *, timeout=None):
+    def fail(req, *, timeout=None):
         assert timeout == 30.0
         raise urllib.error.URLError("boom")
 
@@ -307,9 +307,9 @@ dependencies:
 
     monkeypatch.setenv("EGG_REGISTRY_URL", "http://example.com")
 
-    def fail(url, *, timeout=None):
+    def fail(req, *, timeout=None):
         assert timeout == 30.0
-        raise urllib.error.HTTPError(url, 404, "nope", None, None)
+        raise urllib.error.HTTPError(req.full_url, 404, "nope", None, None)
 
     monkeypatch.setattr(runtime_fetcher, "urlopen", fail)
     with pytest.raises(
@@ -335,7 +335,7 @@ dependencies:
 
     monkeypatch.setenv("EGG_REGISTRY_URL", "http://example.com")
 
-    def fail(url, *, timeout=None):
+    def fail(req, *, timeout=None):
         assert timeout == 30.0
         raise socket.timeout("too slow")
 
@@ -365,7 +365,7 @@ dependencies:
     monkeypatch.setenv("EGG_REGISTRY_URL", "http://example.com")
     monkeypatch.delenv("EGG_DOWNLOAD_TIMEOUT", raising=False)
 
-    def fail(url, *, timeout=None):
+    def fail(req, *, timeout=None):
         assert timeout == 30.0
         raise urllib.error.URLError("boom")
 
@@ -404,7 +404,7 @@ dependencies:
         def __exit__(self, exc_type, exc, tb):
             return False
 
-    def succeed(url, *, timeout=None):
+    def succeed(req, *, timeout=None):
         assert timeout == 12.5
         return Dummy(b"ok")
 

--- a/tests/test_runtime_fetcher_more.py
+++ b/tests/test_runtime_fetcher_more.py
@@ -1,6 +1,7 @@
 import hashlib
 import io
 import urllib.error
+from urllib.request import Request
 from pathlib import Path
 
 import pytest
@@ -50,8 +51,8 @@ def test_download_container_refresh_if_no_digest(monkeypatch, tmp_path: Path) ->
 
     called = []
 
-    def fake_urlopen(url, *, timeout=None):
-        called.append(url)
+    def fake_urlopen(req, *, timeout=None):
+        called.append(req.full_url)
         return Dummy(b"new")
 
     monkeypatch.setattr(rf, "urlopen", fake_urlopen)
@@ -78,8 +79,8 @@ def test_download_container_refresh_on_mismatch(monkeypatch, tmp_path: Path) -> 
 
     called = []
 
-    def fake_urlopen(url, *, timeout=None):
-        called.append(url)
+    def fake_urlopen(req, *, timeout=None):
+        called.append(req.full_url)
         return Dummy(data)
 
     monkeypatch.setattr(rf, "urlopen", fake_urlopen)
@@ -105,7 +106,7 @@ def test_download_container_timeout(monkeypatch, tmp_path: Path) -> None:
         def __exit__(self, *exc):
             pass
 
-    def fake_urlopen(url, *, timeout=None):
+    def fake_urlopen(req, *, timeout=None):
         assert timeout == 5
         return Dummy(b"data")
 
@@ -133,8 +134,8 @@ def test_download_container_repo(monkeypatch, tmp_path: Path) -> None:
 
     called = []
 
-    def fake_urlopen(url, *, timeout=None):
-        called.append(url)
+    def fake_urlopen(req, *, timeout=None):
+        called.append(req.full_url)
         return Dummy(b"data")
 
     monkeypatch.setattr(rf, "urlopen", fake_urlopen)
@@ -142,6 +143,62 @@ def test_download_container_repo(monkeypatch, tmp_path: Path) -> None:
     assert called == ["http://example.com/library/python%3A3.11.img"]
     assert dest.read_bytes() == b"data"
     assert result == dest
+
+
+def test_download_container_default_user_agent(monkeypatch, tmp_path: Path) -> None:
+    dest = tmp_path / "python.img"
+
+    class Dummy(io.BytesIO):
+        def __init__(self, data: bytes) -> None:  # noqa: D401 - simple init
+            super().__init__(data)
+            self.headers = {}
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            pass
+
+    seen: dict[str, str | None] = {}
+
+    def fake_urlopen(req: Request, *, timeout=None):
+        assert isinstance(req, Request)
+        seen["ua"] = req.get_header("User-agent")
+        return Dummy(b"data")
+
+    monkeypatch.setattr(rf, "urlopen", fake_urlopen)
+    rf._download_container("python:3.11", dest, "http://example.com")
+    assert dest.read_bytes() == b"data"
+    assert seen["ua"] == "egg-runtime-fetcher"
+
+
+def test_download_container_user_agent_override(monkeypatch, tmp_path: Path) -> None:
+    dest = tmp_path / "python.img"
+
+    class Dummy(io.BytesIO):
+        def __init__(self, data: bytes) -> None:  # noqa: D401 - simple init
+            super().__init__(data)
+            self.headers = {}
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            pass
+
+    seen: dict[str, str | None] = {}
+
+    def fake_urlopen(req: Request, *, timeout=None):
+        assert isinstance(req, Request)
+        seen["ua"] = req.get_header("User-agent")
+        return Dummy(b"data")
+
+    monkeypatch.setattr(rf, "urlopen", fake_urlopen)
+    rf._download_container(
+        "python:3.11", dest, "http://example.com", user_agent="custom-agent"
+    )
+    assert dest.read_bytes() == b"data"
+    assert seen["ua"] == "custom-agent"
 
 
 def test_fetch_empty_manifest(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- set default `User-Agent` header when downloading runtimes
- allow overriding download header
- add tests for header propagation

## Testing
- `pip install .`
- `pip install -r requirements-dev.txt`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68b9b78796d083289b410329eb239b3c