### PR TITLE
Include command digest in precompute cache

### DIFF
--- a/egg/precompute.py
+++ b/egg/precompute.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import subprocess
 import shutil
 import sys
@@ -11,6 +12,16 @@ from typing import List
 from .manifest import load_manifest
 from .utils import get_lang_command, load_plugins
 from .hashing import sha256_file, write_hashes_file, load_hashes
+
+
+def _hash_command(cmd: List[str]) -> str:
+    """Return a stable hash for ``cmd`` used in the precompute cache."""
+
+    h = hashlib.sha256()
+    for part in cmd:
+        h.update(part.encode("utf-8"))
+        h.update(b"\0")
+    return h.hexdigest()
 
 
 def precompute_cells(
@@ -45,10 +56,13 @@ def precompute_cells(
         src_rel = Path(cell.source)
         src = manifest_dir / src_rel
         digest = sha256_file(src)
-        new_hashes[src_rel.as_posix()] = digest
+        cmd_digest = _hash_command(cmd)
+        cache_value = f"{digest}:{cmd_digest}"
+        new_hashes[src_rel.as_posix()] = cache_value
         out_file = src.with_name(src.name + ".out")
         err_file = src.with_name(src.name + ".err")
-        if prev_hashes.get(src_rel.as_posix()) == digest and out_file.exists():
+        prev_value = prev_hashes.get(src_rel.as_posix())
+        if prev_value == cache_value and out_file.exists():
             outputs.append(out_file)
             continue
         try:

--- a/tests/test_precompute_extra.py
+++ b/tests/test_precompute_extra.py
@@ -8,7 +8,7 @@ import pytest
 sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
 
 from egg.utils import get_lang_command  # noqa: E402
-from egg.precompute import precompute_cells  # noqa: E402
+from egg.precompute import precompute_cells, _hash_command  # noqa: E402
 from egg.hashing import load_hashes, sha256_file  # noqa: E402
 import egg_cli  # noqa: E402
 
@@ -155,7 +155,8 @@ def test_precompute_caches_results(monkeypatch, tmp_path: Path) -> None:
     precompute_cells(manifest)
     assert cache.is_file()
     first_hash = load_hashes(cache)["hello.py"]
-    assert sha256_file(src) == first_hash
+    expected_cmd = get_lang_command("python")
+    assert first_hash == f"{sha256_file(src)}:{_hash_command(expected_cmd)}"
     calls.clear()
 
     precompute_cells(manifest)
@@ -187,6 +188,39 @@ def test_precompute_cache_invalidated(monkeypatch, tmp_path: Path) -> None:
     src.write_text("print('changed')\n")
     precompute_cells(manifest)
     assert len(calls) == 1
+
+
+def test_precompute_cache_invalidated_on_command_change(
+    monkeypatch, tmp_path: Path
+) -> None:
+    src = tmp_path / "hello.py"
+    src.write_text("print('hi')\n")
+    manifest = _write_manifest(tmp_path / "manifest.yaml")
+
+    monkeypatch.setattr(shutil, "which", lambda c: c)
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, stdout=None, **kwargs):
+        calls.append(cmd)
+        if stdout:
+            stdout.write("out\n")
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    precompute_cells(manifest)
+    calls.clear()
+
+    monkeypatch.setenv("EGG_CMD_PYTHON", f"{sys.executable} -u")
+
+    precompute_cells(manifest)
+    assert len(calls) == 1
+
+    cache = tmp_path / "precompute_hashes.yaml"
+    new_hash = load_hashes(cache)["hello.py"]
+    expected = f"{sha256_file(src)}:{_hash_command(get_lang_command('python'))}"
+    assert new_hash == expected
 
 
 def test_precompute_cells_passes_timeout(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- include the runtime command hash alongside the source digest in `precompute_hashes.yaml`
- invalidate cached outputs when either the source digest or interpreter command changes
- extend the precompute tests to cover the new cache format and interpreter switches

## Testing
- pytest tests/test_precompute_extra.py


------
https://chatgpt.com/codex/tasks/task_e_68d82c443fcc8328b853cd2245dc7fd6