### PR TITLE
Refine hatch extraction

### DIFF
--- a/egg_cli.py
+++ b/egg_cli.py
@@ -79,13 +79,44 @@ def hatch(args: argparse.Namespace) -> None:
         raise SystemExit("Hash verification failed")
 
     with zipfile.ZipFile(egg_path) as zf, tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        members: dict[str, str] = {}
         for name in zf.namelist():
             p = PurePosixPath(name)
             if p.is_absolute() or ".." in p.parts:
                 raise SystemExit(f"Unsafe path in archive: {name}")
-        zf.extractall(tmpdir)
-        manifest_path = Path(tmpdir) / "manifest.yaml"
+            if name.endswith("/"):
+                continue  # directories are created on demand
+            members[p.as_posix()] = name
+
+        try:
+            with zf.open("manifest.yaml") as manifest_file:
+                manifest_bytes = manifest_file.read()
+        except KeyError:
+            raise SystemExit("manifest.yaml not found in archive")
+
+        manifest_path = tmp_path / "manifest.yaml"
+        manifest_path.write_bytes(manifest_bytes)
         manifest = load_manifest(manifest_path)
+
+        extracted: set[str] = set()
+
+        def extract_member(member_name: str) -> Path:
+            if member_name in extracted:
+                return tmp_path / member_name
+            if member_name not in members:
+                raise SystemExit(f"Missing file in archive: {member_name}")
+            dest = tmp_path / member_name
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            with zf.open(members[member_name]) as src, open(dest, "wb") as dst:
+                shutil.copyfileobj(src, dst)
+            extracted.add(member_name)
+            return dest
+
+        # Ensure bundled runtime assets are available if present.
+        for name in members:
+            if name.startswith("runtime/"):
+                extract_member(name)
 
         if args.no_sandbox:
             logger.warning("[hatch] Running without sandbox (unsafe)")
@@ -98,7 +129,7 @@ def hatch(args: argparse.Namespace) -> None:
 
         try:
             for cell in manifest.cells:
-                src = Path(tmpdir) / cell.source
+                src = extract_member(cell.source)
                 lang = cell.language.lower()
                 base_cmd = get_lang_command(lang)
                 if base_cmd is None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -174,6 +174,60 @@ def test_hatch(monkeypatch, tmp_path, caplog, os_name, conf_file):
     assert cleanup_called["v"]
 
 
+def test_hatch_selective_extraction(monkeypatch, tmp_path):
+    """Hatching should only read manifest, sources, and runtime assets."""
+
+    egg_path = tmp_path / "demo.egg"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "egg_cli.py",
+            "build",
+            "--manifest",
+            os.path.join("examples", "manifest.yaml"),
+            "--output",
+            str(egg_path),
+        ],
+    )
+    egg_cli.main()
+
+    with zipfile.ZipFile(egg_path, "a") as zf:
+        zf.writestr("unused.txt", "ignore")
+        zf.writestr("runtime/custom.bin", b"data")
+
+    monkeypatch.setattr(egg_cli, "verify_archive", lambda *a, **kw: True)
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, check=True):
+        calls.append(cmd)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(shutil, "which", lambda cmd: cmd)
+
+    opened: list[str] = []
+    real_open = zipfile.ZipFile.open
+
+    def tracking(self, name, *args, **kwargs):
+        if isinstance(name, zipfile.ZipInfo):
+            opened.append(name.filename)
+        else:
+            opened.append(name)
+        return real_open(self, name, *args, **kwargs)
+
+    monkeypatch.setattr(zipfile.ZipFile, "open", tracking)
+
+    monkeypatch.setattr(sys, "argv", ["egg_cli.py", "hatch", "--egg", str(egg_path)])
+    egg_cli.main()
+
+    assert any(cmd[1].endswith("hello.py") for cmd in calls)
+    assert "manifest.yaml" in opened
+    assert any(name.endswith("hello.py") for name in opened)
+    assert "runtime/custom.bin" in opened
+    assert "unused.txt" not in opened
+
+
 def test_hatch_no_sandbox(monkeypatch, tmp_path, caplog):
     egg_path = tmp_path / "demo.egg"
 


### PR DESCRIPTION
## Summary
- update `egg_cli.hatch` to read the manifest directly from the archive and lazily extract referenced files
- ensure runtime assets are materialized when present and surface clear errors when required files are missing
- add a CLI regression test that asserts only manifest, cell sources, and runtime assets are accessed during hatching

## Testing
- pytest tests/test_cli.py


------
https://chatgpt.com/codex/tasks/task_e_68d82c438528832891fa5ddf74bf91bb