### PR TITLE
Use dedicated runtime cache directory

### DIFF
--- a/egg/runtime_fetcher.py
+++ b/egg/runtime_fetcher.py
@@ -23,6 +23,9 @@ from .utils import _is_relative_to
 
 _CHUNK_SIZE = 8192
 _PROGRESS_INTERVAL = 1 << 20  # 1 MiB
+_CACHE_DIR_NAME = ".egg_runtime"
+_CACHE_MARKER_NAME = ".managed-by-egg-runtime-fetcher"
+_CACHE_MARKER_CONTENTS = "Managed by egg.runtime_fetcher; safe to delete.\n"
 
 try:
     import yaml
@@ -43,6 +46,38 @@ def _get_registry_url() -> str | None:
     if conf.is_file():
         return conf.read_text().strip()
     return None
+
+
+def _ensure_cache_dir(cache_dir: Path) -> Path:
+    """Ensure ``cache_dir`` exists and is managed by the runtime fetcher."""
+
+    cache_dir = cache_dir.resolve(strict=False)
+    marker = cache_dir / _CACHE_MARKER_NAME
+
+    if cache_dir.exists():
+        if not cache_dir.is_dir():
+            raise ValueError(
+                f"Runtime cache path exists but is not a directory: {cache_dir}"
+            )
+        if not marker.is_file():
+            raise ValueError(
+                f"Runtime cache directory lacks marker file: {cache_dir}"
+            )
+        try:
+            contents = marker.read_text()
+        except OSError as exc:  # pragma: no cover - filesystem failure
+            raise RuntimeError(
+                f"Unable to read runtime cache marker at {marker}: {exc}"
+            ) from exc
+        if contents != _CACHE_MARKER_CONTENTS:
+            raise ValueError(
+                f"Runtime cache marker mismatch in {cache_dir}; refusing to overwrite"
+            )
+        return cache_dir
+
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    marker.write_text(_CACHE_MARKER_CONTENTS)
+    return cache_dir
 
 
 def _download_container(
@@ -226,6 +261,7 @@ def fetch_runtime_blocks(manifest_path: Path | str) -> List[Path | str]:
     # dependency strings when a clash occurs.
     safe_names: dict[str, str] = {}
     registry = _get_registry_url()
+    cache_dir: Path | None = None
 
     for dep in deps:
         if not isinstance(dep, str):
@@ -247,6 +283,12 @@ def fetch_runtime_blocks(manifest_path: Path | str) -> List[Path | str]:
                 raise ValueError(f"Invalid container image name: {dep}")
 
             if registry:
+                if cache_dir is None:
+                    cache_dir = _ensure_cache_dir(manifest_dir / _CACHE_DIR_NAME)
+                    if not _is_relative_to(cache_dir, manifest_dir):
+                        raise ValueError(
+                            f"Runtime cache escapes manifest directory: {cache_dir}"
+                        )
                 safe = dep.replace("/", "_").replace("\\", "_").replace(":", "_")
                 if safe in safe_names:
                     other = safe_names[safe]
@@ -255,7 +297,11 @@ def fetch_runtime_blocks(manifest_path: Path | str) -> List[Path | str]:
                         f"{dep!r} and {other!r} both map to {safe!r}"
                     )
                 safe_names[safe] = dep
-                dest = (manifest_dir / f"{safe}.img").resolve(strict=False)
+                dest = (cache_dir / f"{safe}.img").resolve(strict=False)
+                if not _is_relative_to(dest, cache_dir):
+                    raise ValueError(
+                        f"Dependency path escapes manifest directory: {dep}"
+                    )
                 if not _is_relative_to(dest, manifest_dir):
                     raise ValueError(
                         f"Dependency path escapes manifest directory: {dep}"

--- a/tests/test_runtime_fetcher.py
+++ b/tests/test_runtime_fetcher.py
@@ -169,11 +169,14 @@ dependencies:
     )
 
     paths = fetch_runtime_blocks(manifest)
-    expected = tmp_path / "python_3.11.img"
+    expected = tmp_path / ".egg_runtime" / "python_3.11.img"
     server.shutdown()
     thread.join()
     assert paths == [expected]
     assert expected.read_text() == "image"
+    marker = expected.parent / runtime_fetcher._CACHE_MARKER_NAME
+    assert marker.is_file()
+    assert marker.read_text() == runtime_fetcher._CACHE_MARKER_CONTENTS
 
 
 def test_registry_download_env_repo(monkeypatch, tmp_path: Path) -> None:
@@ -199,7 +202,7 @@ dependencies:
     )
 
     paths = fetch_runtime_blocks(manifest)
-    expected = tmp_path / "library_python_3.11.img"
+    expected = tmp_path / ".egg_runtime" / "library_python_3.11.img"
     server.shutdown()
     thread.join()
     assert paths == [expected]
@@ -233,11 +236,93 @@ dependencies:
     )
 
     paths = fetch_runtime_blocks(manifest)
-    expected = tmp_path / "r_4.3.img"
+    expected = tmp_path / ".egg_runtime" / "r_4.3.img"
     server.shutdown()
     thread.join()
     assert paths == [expected]
     assert expected.read_text() == "rimage"
+
+
+def test_runtime_cache_without_marker(monkeypatch, tmp_path: Path) -> None:
+    (tmp_path / "code.py").write_text("print('hi')\n")
+    cache_dir = tmp_path / ".egg_runtime"
+    cache_dir.mkdir()
+    manifest = tmp_path / "manifest.yaml"
+    manifest.write_text(
+        """
+name: Example
+description: desc
+cells:
+  - language: python
+    source: code.py
+dependencies:
+  - python:3.11
+"""
+    )
+
+    monkeypatch.setenv("EGG_REGISTRY_URL", "http://example.com")
+    with pytest.raises(ValueError, match="marker"):
+        fetch_runtime_blocks(manifest)
+
+
+def test_runtime_cache_marker_mismatch(monkeypatch, tmp_path: Path) -> None:
+    (tmp_path / "code.py").write_text("print('hi')\n")
+    cache_dir = tmp_path / ".egg_runtime"
+    cache_dir.mkdir()
+    (cache_dir / runtime_fetcher._CACHE_MARKER_NAME).write_text("not-right\n")
+    manifest = tmp_path / "manifest.yaml"
+    manifest.write_text(
+        """
+name: Example
+description: desc
+cells:
+  - language: python
+    source: code.py
+dependencies:
+  - python:3.11
+"""
+    )
+
+    monkeypatch.setenv("EGG_REGISTRY_URL", "http://example.com")
+    with pytest.raises(ValueError, match="marker mismatch"):
+        fetch_runtime_blocks(manifest)
+
+
+def test_runtime_cache_reuse(monkeypatch, tmp_path: Path) -> None:
+    (tmp_path / "code.py").write_text("print('hi')\n")
+    cache_dir = tmp_path / ".egg_runtime"
+    cache_dir.mkdir()
+    marker = cache_dir / runtime_fetcher._CACHE_MARKER_NAME
+    marker.write_text(runtime_fetcher._CACHE_MARKER_CONTENTS)
+    cached = cache_dir / "python_3.11.img"
+    cached.write_text("stale")
+
+    server, thread = _start_server(tmp_path)
+    registry_url = f"http://localhost:{server.server_address[1]}"
+    monkeypatch.setenv("EGG_REGISTRY_URL", registry_url)
+
+    (tmp_path / "python:3.11.img").write_text("fresh")
+
+    manifest = tmp_path / "manifest.yaml"
+    manifest.write_text(
+        """
+name: Example
+description: desc
+cells:
+  - language: python
+    source: code.py
+dependencies:
+  - python:3.11
+"""
+    )
+
+    paths = fetch_runtime_blocks(manifest)
+    server.shutdown()
+    thread.join()
+
+    assert paths == [cached]
+    assert cached.read_text() == "fresh"
+    assert marker.read_text() == runtime_fetcher._CACHE_MARKER_CONTENTS
 
 
 def test_registry_traversal_rejected(monkeypatch, tmp_path: Path) -> None:
@@ -410,7 +495,7 @@ dependencies:
 
     monkeypatch.setattr(runtime_fetcher, "urlopen", succeed)
     paths = fetch_runtime_blocks(manifest)
-    expected = tmp_path / "python_3.11.img"
+    expected = tmp_path / ".egg_runtime" / "python_3.11.img"
     assert paths == [expected]
     assert expected.read_bytes() == b"ok"
 


### PR DESCRIPTION
## Summary
- store downloaded runtime images inside a managed .egg_runtime cache directory with marker validation
- ensure the runtime fetcher only reuses caches that it created and rejects missing/mismatched markers
- update runtime fetcher tests to cover the new cache location and marker safeguards

## Testing
- pytest tests/test_runtime_fetcher.py tests/test_runtime_fetcher_more.py
- pytest tests/test_runtime_fetcher_extra.py

------
https://chatgpt.com/codex/tasks/task_e_68d82c4239bc8328a462c3e04a8973e6