### PR TITLE
Refactor runtime_fetcher to reuse manifest dependency validation

### DIFF
--- a/egg/manifest.py
+++ b/egg/manifest.py
@@ -54,6 +54,44 @@ def _normalize_source(path: str | Path, manifest_dir: Path) -> str:
     return abs_path.relative_to(manifest_dir).as_posix()
 
 
+def _load_manifest_yaml(path: Path | str) -> dict:
+    """Load raw manifest YAML data and ensure the root is a mapping."""
+    with open(path, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+
+    if data is None:
+        data = {}
+    if not isinstance(data, dict):
+        raise ValueError("Manifest root must be a mapping")
+    return data
+
+
+def _validate_dependencies(deps_data: object) -> List[str] | None:
+    """Validate and normalize ``dependencies`` data from a manifest."""
+    dependencies: List[str] | None
+    if deps_data is None:
+        dependencies = None
+    else:
+        if not isinstance(deps_data, list):
+            raise ValueError("'dependencies' must be a list")
+        dep_set: set[str] = set()
+        dependencies = []
+        for dep in deps_data:
+            if not isinstance(dep, str):
+                raise ValueError("dependency entries must be strings")
+            if dep in dep_set:
+                raise ValueError(f"Duplicate dependency: {dep}")
+            dep_set.add(dep)
+            dependencies.append(dep)
+    return dependencies
+
+
+def load_manifest_dependencies(path: Path | str) -> List[str] | None:
+    """Load and validate only the ``dependencies`` section of a manifest."""
+    data = _load_manifest_yaml(path)
+    return _validate_dependencies(data.get("dependencies"))
+
+
 def load_manifest(path: Path | str) -> Manifest:
     """Load a manifest from a YAML file.
 
@@ -66,11 +104,7 @@ def load_manifest(path: Path | str) -> Manifest:
     Raises:
         ValueError: If required fields are missing or malformed.
     """
-    with open(path, "r", encoding="utf-8") as f:
-        data = yaml.safe_load(f)
-
-    if not isinstance(data, dict):
-        raise ValueError("Manifest root must be a mapping")
+    data = _load_manifest_yaml(path)
 
     required_fields = {"name", "description", "cells"}
     optional_fields = {"permissions", "dependencies", "author", "created", "license"}
@@ -108,22 +142,7 @@ def load_manifest(path: Path | str) -> Manifest:
                 raise ValueError(f"Permission '{perm}' must be a boolean")
             permissions[perm] = val
 
-    deps_data = data.get("dependencies")
-    dependencies: List[str] | None
-    if deps_data is None:
-        dependencies = None
-    else:
-        if not isinstance(deps_data, list):
-            raise ValueError("'dependencies' must be a list")
-        dep_set: set[str] = set()
-        dependencies = []
-        for dep in deps_data:
-            if not isinstance(dep, str):
-                raise ValueError("dependency entries must be strings")
-            if dep in dep_set:
-                raise ValueError(f"Duplicate dependency: {dep}")
-            dep_set.add(dep)
-            dependencies.append(dep)
+    dependencies = _validate_dependencies(data.get("dependencies"))
 
     author_data = data.get("author")
     if author_data is not None and not isinstance(author_data, str):

--- a/egg/runtime_fetcher.py
+++ b/egg/runtime_fetcher.py
@@ -18,6 +18,7 @@ import socket
 from pathlib import Path, PurePosixPath
 from typing import List
 
+from .manifest import load_manifest_dependencies
 from .utils import _is_relative_to
 
 
@@ -26,13 +27,6 @@ _PROGRESS_INTERVAL = 1 << 20  # 1 MiB
 _CACHE_DIR_NAME = ".egg_runtime"
 _CACHE_MARKER_NAME = ".managed-by-egg-runtime-fetcher"
 _CACHE_MARKER_CONTENTS = "Managed by egg.runtime_fetcher; safe to delete.\n"
-
-try:
-    import yaml
-except ModuleNotFoundError as exc:  # pragma: no cover - import guard
-    raise ModuleNotFoundError(
-        "PyYAML is required to use the runtime fetcher. Install with 'pip install PyYAML'"
-    ) from exc
 
 logger = logging.getLogger(__name__)
 
@@ -237,22 +231,12 @@ def fetch_runtime_blocks(manifest_path: Path | str) -> List[Path | str]:
     """
 
     manifest_path = Path(manifest_path)
-    with open(manifest_path, "r", encoding="utf-8") as f:
-        manifest = yaml.safe_load(f)
-    if manifest is None:
-        manifest = {}
-    if not isinstance(manifest, dict):
-        raise ValueError("Manifest root must be a mapping")
-
-    deps = manifest.get("dependencies", [])
+    deps = load_manifest_dependencies(manifest_path)
     if deps is None:
         return []
-    if not isinstance(deps, list):
-        raise ValueError("'dependencies' must be a list")
 
     manifest_dir = manifest_path.parent.resolve()
     resolved: List[Path | str] = []
-    seen: set[str] = set()
     # Track sanitized container filenames to avoid collisions when
     # downloading multiple images that differ only by characters replaced
     # during sanitization. Mapping allows us to report the original conflicting
@@ -262,11 +246,6 @@ def fetch_runtime_blocks(manifest_path: Path | str) -> List[Path | str]:
     cache_dir: Path | None = None
 
     for dep in deps:
-        if not isinstance(dep, str):
-            raise ValueError("dependency entries must be strings")
-        if dep in seen:
-            raise ValueError(f"Duplicate dependency entry: {dep}")
-        seen.add(dep)
         if ":" in dep:
             if "\\" in dep:
                 raise ValueError(f"Invalid container image name: {dep}")

--- a/tests/test_runtime_fetcher_extra.py
+++ b/tests/test_runtime_fetcher_extra.py
@@ -3,6 +3,7 @@ import sys
 from pathlib import Path
 import pytest
 
+import egg.runtime_fetcher as rf
 sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
 
 from egg.runtime_fetcher import fetch_runtime_blocks  # noqa: E402
@@ -56,3 +57,17 @@ def test_manifest_root_not_mapping(tmp_path: Path) -> None:
     manifest.write_text("- just a list\n")
     with pytest.raises(ValueError, match="Manifest root must be a mapping"):
         fetch_runtime_blocks(manifest)
+
+
+def test_fetch_runtime_uses_manifest_dependency_loader(monkeypatch, tmp_path: Path) -> None:
+    manifest = tmp_path / "manifest.yaml"
+    manifest.write_text("dependencies: null\n")
+    called = []
+
+    def fake_loader(path: Path) -> list[str] | None:
+        called.append(path)
+        return []
+
+    monkeypatch.setattr(rf, "load_manifest_dependencies", fake_loader)
+    assert fetch_runtime_blocks(manifest) == []
+    assert called == [manifest]


### PR DESCRIPTION
### Motivation
- Centralize manifest YAML root loading and `dependencies` validation to avoid duplicated parsing and checks across modules. 
- Keep `runtime_fetcher` focused on runtime-specific concerns (image sanitization, cache handling, downloads) while reusing manifest validation logic.

### Description
- Added `_load_manifest_yaml`, `_validate_dependencies`, and `load_manifest_dependencies` helpers in `egg/manifest.py` to expose dependency-only parsing and validation. 
- Updated `load_manifest` to reuse the new dependency validator instead of duplicating dependency checks. 
- Refactored `egg/runtime_fetcher.py::fetch_runtime_blocks` to call `load_manifest_dependencies` and removed redundant root/type/duplicate checks while preserving container sanitization, cache marker/path checks, and download behavior. 
- Added a test `test_fetch_runtime_uses_manifest_dependency_loader` in `tests/test_runtime_fetcher_extra.py` to assert that `fetch_runtime_blocks` uses the shared loader. 

### Testing
- Ran `pytest -q tests/test_runtime_fetcher.py tests/test_runtime_fetcher_extra.py tests/test_runtime_fetcher_more.py tests/test_manifest.py` and all tests completed successfully. 
- Test summary: `64 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d17ef54fd0832886484a659273b02f)